### PR TITLE
feat: Add option to filter mutations by file, lines, and definitions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,6 +56,7 @@ jobs:
           cargo test -p cargo-mutest --no-fail-fast -- --color=always
           cargo test -p mutest-runtime --no-fail-fast -- --color=always
           cargo test -p mutest-inspector --no-fail-fast -- --color=always
+          cargo test -p mutest-tests --no-fail-fast -- --color=always
 
       - name: Run UI tests
         run: cargo ui-test

--- a/cargo-mutest/src/main.rs
+++ b/cargo-mutest/src/main.rs
@@ -395,7 +395,7 @@ fn main() {
     if cfg!(windows) { path.set_extension("exe"); }
     cmd.env("RUSTC_WORKSPACE_WRAPPER", path);
 
-    cmd.env("MUTEST_ARGS", mutest_args.join(" "));
+    cmd.env("MUTEST_ENCODED_ARGS", mutest_args.join("\x1F"));
 
     if let Some(passed_args) = passed_args {
         cmd.arg("--");

--- a/mutest-driver-cli/src/lib.rs
+++ b/mutest-driver-cli/src/lib.rs
@@ -143,6 +143,13 @@ pub fn command() -> clap::Command {
         .arg(clap::arg!(--"call-graph-depth-limit" [CALL_GRAPH_DEPTH_LIMIT] "Limit depth of call graph analysis, which is complete by default.").value_parser(clap::value_parser!(usize)).display_order(150))
         .arg(clap::arg!(--"call-graph-trace-length-limit" [CALL_GRAPH_TRACE_LENGTH_LIMIT] "Limit maximum length of analyzed call traces during call graph analysis, which is complete by default.").value_parser(clap::value_parser!(usize)).display_order(150))
         .arg(clap::arg!(-d --depth [DEPTH] "Callees of each test function are mutated up to the specified depth.").default_value("3").value_parser(clap::value_parser!(usize)).display_order(150))
+        .arg(clap::arg!(--"filter-mutations" [MUTATION_FILTERS]).value_delimiter(',').display_order(150)
+            .help("\
+                Filter mutations to only the ones specified by any of the filters. Multiple may be specified, seperated by commas. The following filters are available:\n\
+                * `def:<ITEM_PATH_TO_DEF>`: Only mutate the specified definition. The full canonical item path must be specified (e.g., `def:foo::bar::baz`, `def:Struct::function`, `def:<Struct as Trait>::function`).\n\
+                * `file:<PATH_TO_FILE>[:<LINE>[:<END_LINE>]]`: Only mutate the specified file, or the specified part of the file (e.g., `file:src/lib.rs`, `file:src/lib.rs:21`, `file:src/lib.rs:21:25`).
+            ")
+        )
         .arg(clap::arg!(--"parallel-mutants" "Enable the parallel evaluation of mutations using dynamic mutation scheduling.").display_order(198))
         .arg(clap::arg!(--"mutant-batch-algorithm" [MUTANT_BATCH_ALGORITHM] "Algorithm to use to optionally batch mutations into parallel groups.").value_parser(mutant_batch_algorithm::possible_values()).default_value(mutant_batch_algorithm::NONE).display_order(199))
         .arg(clap::arg!(--"mutant-batch-size" [MUTANT_BATCH_SIZE] "Maximum number of mutations to batch into a single batch.").default_value("1").value_parser(clap::value_parser!(usize)).display_order(199))

--- a/mutest-driver/src/config.rs
+++ b/mutest-driver/src/config.rs
@@ -157,6 +157,14 @@ pub struct VerifyOptions {
     pub ast_lowering: bool,
 }
 
+#[derive(Clone, Debug)]
+pub enum MutationFilter {
+    /// `file:path/to/src.rs` or `file:path/to/src.rs:15` or `file:path/to/src.rs:15:17`.
+    File(PathBuf, Option<(usize, Option<usize>)>),
+    /// `def:path::to::function` or `def:<impl path::to::Trait for path::to::Type>::function`, using fully-qualified (without root crate) Rust item paths.
+    Def(String),
+}
+
 pub struct Options<'op, 'm> {
     pub crate_kind: CrateKind,
     pub cargo_target_kind: Option<CargoTargetKind>,
@@ -171,6 +179,7 @@ pub struct Options<'op, 'm> {
     pub call_graph_depth_limit: Option<usize>,
     pub call_graph_trace_length_limit: Option<usize>,
     pub mutation_depth: usize,
+    pub mutation_filters: Vec<MutationFilter>,
     pub mutation_parallelism: Option<MutationParallelism>,
 
     pub verify_opts: VerifyOptions,

--- a/mutest-driver/src/main.rs
+++ b/mutest-driver/src/main.rs
@@ -202,12 +202,14 @@ pub fn main() {
         || args.iter().position(|arg| arg == "--crate-type").is_some_and(|i| args.get(i + 1).is_some_and(|v| v == "bin"));
 
     let mutest_args = (!rustc_wrapper)
-        .then_some(args.iter().skip(1).map(ToOwned::to_owned).collect::<Vec<_>>().join(" "))
-        .or_else(|| env::var("MUTEST_ARGS").ok());
+        .then_some(args.iter().skip(1).map(ToOwned::to_owned).collect::<Vec<_>>())
+        .or_else(|| env::var("MUTEST_ENCODED_ARGS").ok().map(|args| args.split('\x1F').map(ToOwned::to_owned).collect::<Vec<_>>()))
+        .or_else(|| env::var("MUTEST_ARGS").ok().map(|args| args.split(' ').map(ToOwned::to_owned).collect::<Vec<_>>()));
+    let mutest_args_str = mutest_args.as_ref().map(|mutest_args| mutest_args.join(" "));
 
     if normal_rustc || !primary_package || (bin_target && !test_target) {
         process::exit(rustc_driver::catch_with_exit_code(|| {
-            rustc_driver::run_compiler(&args, &mut RustcCallbacks { mutest_args })
+            rustc_driver::run_compiler(&args, &mut RustcCallbacks { mutest_args: mutest_args_str })
         }));
     }
 
@@ -215,7 +217,7 @@ pub fn main() {
         .no_binary_name(true)
         // Target-related Arguments
         .arg(clap::arg!(--"crate-kind" [CRATE_KIND] "Determine how the crate is handled in terms of mutations and tests.").value_parser(crate_kind::possible_values()).default_value(crate_kind::INFER).display_order(200))
-        .get_matches_from(mutest_args.as_deref().unwrap_or_default().split(" "));
+        .get_matches_from(mutest_args.unwrap_or_default());
 
     process::exit(rustc_driver::catch_with_exit_code(|| {
         let compiler_config = mutest_driver::passes::parse_compiler_args(&args).expect("no compiler configuration was generated");
@@ -628,7 +630,7 @@ pub fn main() {
 
         let config = Config {
             compiler_config,
-            invocation_fingerprint: mutest_args,
+            invocation_fingerprint: mutest_args_str,
             mutest_target_dir_root,
             mutest_search_path,
             opts: config::Options {

--- a/mutest-driver/src/main.rs
+++ b/mutest-driver/src/main.rs
@@ -459,6 +459,41 @@ pub fn main() {
             call_graph_trace_length_limit = None;
         }
 
+        let mutation_filters = mutest_arg_matches.get_many::<String>("filter-mutations").into_iter().flatten()
+            .map(|filter| {
+                match () {
+                    _ if let Some(def_path_str) = filter.strip_prefix("def:") => {
+                        config::MutationFilter::Def(def_path_str.to_owned())
+                    }
+                    _ if let Some(file_spec) = filter.strip_prefix("file:") => {
+                        let mut file_path_str = file_spec;
+                        let mut line_range_str = None;
+                        if let Some((file_spec_rest, line_no_str_part)) = file_spec.rsplit_once(':') {
+                            if let Some((file_path_str_part, start_line_no_str_part)) = file_spec_rest.rsplit_once(':') {
+                                file_path_str = file_path_str_part;
+                                line_range_str = Some((start_line_no_str_part, Some(line_no_str_part)));
+                            } else {
+                                file_path_str = file_spec_rest;
+                                line_range_str = Some((line_no_str_part, None));
+                            }
+                        }
+
+                        let line_range = line_range_str.map(|(line_no_str, end_line_no_str)| -> Result<_, std::num::ParseIntError> {
+                            let line_no = line_no_str.parse::<usize>()?;
+                            let end_line_no = end_line_no_str.map(|end_line_no_str| end_line_no_str.parse::<usize>()).transpose()?;
+                            Ok((line_no, end_line_no))
+                        }).transpose();
+                        let line_range = match line_range {
+                            Ok(line_range) => line_range,
+                            Err(_error) => early_dcx.early_fatal(format!("invalid mutation filter argument: `{filter}`")),
+                        };
+                        config::MutationFilter::File(PathBuf::from(file_path_str), line_range)
+                    }
+                    _ => early_dcx.early_fatal(format!("invalid mutation filter argument: `{filter}`")),
+                }
+            })
+            .collect::<Vec<_>>();
+
         let mutation_parallelism = 'mutation_parallelism: {
             let mutation_parallelism_config = package_config.as_ref().and_then(|c| c.mutation_parallelism.as_ref());
 
@@ -609,6 +644,7 @@ pub fn main() {
                 call_graph_depth_limit,
                 call_graph_trace_length_limit,
                 mutation_depth,
+                mutation_filters,
                 mutation_parallelism,
 
                 write_opts,

--- a/mutest-driver/src/passes/analysis.rs
+++ b/mutest-driver/src/passes/analysis.rs
@@ -7,7 +7,7 @@ use rustc_interface::interface::Result as CompilerResult;
 use rustc_middle::bug;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::config::OptLevel;
-use rustc_span::ErrorGuaranteed;
+use rustc_span::{ErrorGuaranteed, FileName};
 use rustc_span::edition::Edition;
 use rustc_span::fatal_error::FatalError;
 use mutest_emit::analysis::call_graph::{EntryPointAssocs, EntryPoints, Targeting, TargetReachability};
@@ -292,6 +292,7 @@ pub fn run(config: &mut Config) -> CompilerResult<Option<AnalysisPassResult>> {
                     let t_target_analysis_start = Instant::now();
 
                     let (call_graph, mut reachable_fns) = mutest_emit::analysis::call_graph::reachable_fns(tcx, &def_res, &generated_crate_ast, entry_points, targeting, call_graph_depth_limit, call_graph_trace_length_limit);
+                    let reachable_fns_count = reachable_fns.len();
                     let mut json_definitions = Default::default();
                     if let Some(write_opts) = &opts.write_opts {
                         let t_write_start = Instant::now();
@@ -304,8 +305,8 @@ pub fn run(config: &mut Config) -> CompilerResult<Option<AnalysisPassResult>> {
                         );
 
                         println!("reached {reached_pct:.2}% of functions from tests ({reached} out of {total} functions)",
-                            reached_pct = reachable_fns.len() as f64 / all_mutable_fns_count as f64 * 100_f64,
-                            reached = reachable_fns.len(),
+                            reached_pct = reachable_fns_count as f64 / all_mutable_fns_count as f64 * 100_f64,
+                            reached = reachable_fns_count,
                             total = all_mutable_fns_count,
                         );
 
@@ -350,12 +351,46 @@ pub fn run(config: &mut Config) -> CompilerResult<Option<AnalysisPassResult>> {
                         if opts.verbosity >= 1 { println!(); }
                     }
 
-                    let targets = reachable_fns.into_iter()
+                    let mut targets = reachable_fns.into_iter()
                         .filter(|f| match f.reachability {
                             TargetReachability::DirectEntry => true,
                             TargetReachability::NestedCallee { distance } => distance < opts.mutation_depth,
                         })
                         .collect::<Vec<_>>();
+
+                    // Target-level filtering of mutations.
+                    // NOTE: The rest of the intra-target filtering happens later.
+                    if !opts.mutation_filters.is_empty() {
+                        targets.retain(|target| opts.mutation_filters.iter().any(|filter| match filter {
+                            config::MutationFilter::File(path, line_range) => {
+                                let target_span = tcx.def_span(target.def_id());
+                                let FileName::Real(target_file_name) = sess.source_map().span_to_filename(target_span) else { return false; };
+                                if target_file_name.local_path() != Some(path) { return false; }
+
+                                if let Some((start_line_no, end_line_no)) = *line_range && let Some(target_local_def_id) = target.def_id().as_local() {
+                                    let target_span_with_body = tcx.hir_span_with_body(tcx.local_def_id_to_hir_id(target_local_def_id));
+                                    let lo_loc = sess.source_map().lookup_char_pos(target_span_with_body.lo());
+                                    let hi_loc = sess.source_map().lookup_char_pos(target_span_with_body.hi());
+
+                                    let end_line_no = end_line_no.unwrap_or(start_line_no);
+                                    if !(lo_loc.line <= end_line_no && start_line_no <= hi_loc.line) { return false; }
+                                }
+
+                                true
+                            }
+                            config::MutationFilter::Def(def_path_str) => {
+                                tcx.def_path_str(target.def_id()) == *def_path_str
+                            }
+                        }));
+
+                        if opts.verbosity >= 1 {
+                            println!("filtered to {filtered_pct:.2}% of functions ({filtered} out of {total} functions)",
+                                filtered_pct = targets.len() as f64 / reachable_fns_count as f64 * 100_f64,
+                                filtered = targets.len(),
+                                total = reachable_fns_count,
+                            );
+                        }
+                    }
 
                     pass_result.target_analysis_duration = t_target_analysis_start.elapsed();
 
@@ -447,7 +482,29 @@ pub fn run(config: &mut Config) -> CompilerResult<Option<AnalysisPassResult>> {
             }
 
             let t_mutation_generation_start = Instant::now();
-            let mutations = mutest_emit::codegen::mutation::apply_mutation_operators(tcx, &crate_res, &def_res, &body_res, &generated_crate_ast, &targets, &opts.operators, opts.unsafe_targeting, &sess_opts);
+            let mut mutations = mutest_emit::codegen::mutation::apply_mutation_operators(tcx, &crate_res, &def_res, &body_res, &generated_crate_ast, &targets, &opts.operators, opts.unsafe_targeting, &sess_opts);
+            if !opts.mutation_filters.is_empty() {
+                // NOTE: Targets are already filtered, so this only applies intra-target filtering.
+                mutations.retain(|mutation| opts.mutation_filters.iter().any(|filter| {
+                    match filter {
+                        config::MutationFilter::File(path, line_range) => {
+                            let (Some(source_file), lo_line, _, hi_line, _) = sess.source_map().span_to_location_info(mutation.span) else { return false; };
+                            let FileName::Real(file_name) = &source_file.name else { return false; };
+                            file_name.local_path() == Some(path) && match *line_range {
+                                None => true,
+                                Some((line_no, None)) => lo_line <= line_no && line_no <= hi_line,
+                                Some((start_line_no, Some(end_line_no))) => lo_line <= end_line_no && start_line_no <= hi_line,
+                            }
+                        }
+                        config::MutationFilter::Def(def_path_str) => {
+                            tcx.def_path_str(mutation.target.def_id()) == *def_path_str
+                        }
+                    }
+                }));
+
+                // NOTE: Mutations have to be reindexed after filtering for sequential ID assumptions to hold.
+                mutest_emit::codegen::mutation::reindex_mutations(&mut mutations);
+            }
             if opts.verbosity >= 1 {
                 let mutated_fns = mutations.iter().map(|m| m.target.def_id()).collect::<FxHashSet<_>>();
                 let mutated_fns_count = mutated_fns.len();

--- a/mutest-driver/src/passes/external_mutant/specialized_crate.rs
+++ b/mutest-driver/src/passes/external_mutant/specialized_crate.rs
@@ -83,6 +83,7 @@ pub fn compile_specialized_mutant_crate(
             call_graph_depth_limit: config.opts.call_graph_depth_limit,
             call_graph_trace_length_limit: config.opts.call_graph_trace_length_limit,
             mutation_depth: config.opts.mutation_depth,
+            mutation_filters: config.opts.mutation_filters.clone(),
             mutation_parallelism: config.opts.mutation_parallelism.clone(),
 
             write_opts: config.opts.write_opts.clone(),

--- a/mutest-emit/src/codegen/mutation.rs
+++ b/mutest-emit/src/codegen/mutation.rs
@@ -1,4 +1,5 @@
 use std::hash::{Hash, Hasher};
+use std::iter;
 use std::marker::PhantomData;
 
 use rustc_hash::{FxHashSet, FxHashMap};
@@ -666,6 +667,12 @@ pub fn apply_mutation_operators<'ast, 'tcx, 'trg, 'm>(
     }
 
     collector.mutations
+}
+
+pub fn reindex_mutations<'trg, 'm>(mutations: &mut [Mut<'trg, 'm>]) {
+    for (id, mutation) in iter::zip(1.., mutations) {
+        mutation.id = MutId(id);
+    }
 }
 
 pub enum MutationError<'trg, 'm> {

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -509,7 +509,7 @@ fn run_test(path: &Path, aux_dir_path: &Path, root_dir: &Path, opts: &Opts, resu
         .flat_map(|flags| flags.split(" ").filter(|flag| !flag.is_empty()).map(str::to_owned))
         .collect_into(&mut mutest_args);
     mutest_args.push(mutest_subcommand.to_owned());
-    cmd.env("MUTEST_ARGS".to_owned(), mutest_args.join(" "));
+    cmd.env("MUTEST_ENCODED_ARGS".to_owned(), mutest_args.join("\x1F"));
 
     // NOTE: Avoid passing on the `CARGO_*` environment variables from the test runner.
     for (var, _) in env::vars() {

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -172,6 +172,62 @@ fn parse_directives(path: &Path) -> Vec<String> {
     directives
 }
 
+fn parse_args(args_str: &str) -> Vec<&str> {
+    let mut args = vec![];
+
+    let mut char_indices_iter = args_str.char_indices();
+    while let Some((c_idx, c)) = char_indices_iter.next() {
+        // NOTE: Skip past multiple consecutive whitespace separators between args.
+        if c.is_whitespace() { continue; }
+
+        let (start_idx, end_idx) = match c {
+            '"' => {
+                let start_idx = char_indices_iter.offset();
+                let end_idx = 'end_idx: {
+                    while let Some((c_idx, c)) = char_indices_iter.next() {
+                        if c != '"' { continue; }
+                        match char_indices_iter.clone().next() {
+                            None => { break 'end_idx c_idx; }
+                            Some((_, next_c)) if next_c.is_whitespace() => {
+                                // NOTE: Skip past the whitespace character after `"`.
+                                let _ = char_indices_iter.next();
+                                break 'end_idx c_idx;
+                            }
+                            _ => { continue; }
+                        }
+                    }
+                    // NOTE: This is the fallback value if `"` is not closed by the end of the args list.
+                    args_str.len()
+                };
+                (start_idx, end_idx)
+            }
+            _ => {
+                let end_idx = 'end_idx: {
+                    while let Some((c_idx, c)) = char_indices_iter.next() {
+                        if c.is_whitespace() { break 'end_idx c_idx; }
+                    }
+                    args_str.len()
+                };
+                (c_idx, end_idx)
+            }
+        };
+
+        args.push(&args_str[start_idx..end_idx]);
+    }
+
+    args
+}
+
+#[test]
+fn test_parse_args() {
+    assert_eq!(["foo", "bar", "baz"], parse_args("foo bar baz")[..]);
+    assert_eq!(["foo", "bar", "baz"], parse_args("foo   bar   baz")[..]);
+    assert_eq!(["foo", "bar baz", "abc"], parse_args("foo \"bar baz\" abc")[..]);
+    assert_eq!(["foo", "bar=\"baz\"", "abc"], parse_args("foo \"bar=\"baz\"\" abc")[..]);
+    assert_eq!(["foo", "bar baz"], parse_args("foo \"bar baz\"")[..]);
+    assert_eq!(["foo", "bar baz"], parse_args("foo \"bar baz")[..]);
+}
+
 fn run_test(path: &Path, aux_dir_path: &Path, root_dir: &Path, opts: &Opts, results: &mut TestRunResults) {
     if !path.is_file() { return; }
     if !path.extension().is_some_and(|v| v == "rs") { return; }
@@ -478,8 +534,7 @@ fn run_test(path: &Path, aux_dir_path: &Path, root_dir: &Path, opts: &Opts, resu
         cmd.env(key, val);
     }
 
-    let rustc_flags = directives.iter().filter_map(|d| d.strip_prefix("rustc-flags:").map(str::trim))
-        .flat_map(|flags| flags.split(" ").filter(|flag| !flag.is_empty()));
+    let rustc_flags = directives.iter().filter_map(|d| d.strip_prefix("rustc-flags:").map(str::trim)).flat_map(parse_args);
     cmd.args(rustc_flags);
 
     if aux {
@@ -506,7 +561,7 @@ fn run_test(path: &Path, aux_dir_path: &Path, root_dir: &Path, opts: &Opts, resu
         mutest_args.push(mutest_prints.into_iter().intersperse(",").collect::<String>());
     }
     directives.iter().filter_map(|d| d.strip_prefix("mutest-flags:").map(str::trim))
-        .flat_map(|flags| flags.split(" ").filter(|flag| !flag.is_empty()).map(str::to_owned))
+        .flat_map(|flags| parse_args(flags).into_iter().map(str::to_owned))
         .collect_into(&mut mutest_args);
     mutest_args.push(mutest_subcommand.to_owned());
     cmd.env("MUTEST_ENCODED_ARGS".to_owned(), mutest_args.join("\x1F"));
@@ -561,8 +616,7 @@ fn run_test(path: &Path, aux_dir_path: &Path, root_dir: &Path, opts: &Opts, resu
             cmd.env(key, val);
         }
 
-        let run_flags = directives.iter().filter_map(|d| d.strip_prefix("run-flags:").map(str::trim))
-            .flat_map(|flags| flags.split(" ").filter(|flag| !flag.is_empty()));
+        let run_flags = directives.iter().filter_map(|d| d.strip_prefix("run-flags:").map(str::trim)).flat_map(parse_args);
         cmd.args(run_flags);
 
         // NOTE: Avoid passing on the `CARGO_*` environment variables from the test runner.

--- a/tests/ui/mutation/filter/filter_by_def.rs
+++ b/tests/ui/mutation/filter/filter_by_def.rs
@@ -1,0 +1,29 @@
+//@ print-targets
+//@ print-mutations
+//@ stdout
+//@ stderr: empty
+//@ mutest-flags: -v --filter-mutations=def:inner::mutable_fn
+
+#![allow(unused)]
+
+const fn immutable_fn() {}
+
+fn unreached_mutable_fn(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+mod inner {
+    fn mutable_fn(a: u32, b: u32) -> u32 {
+        a + b
+    }
+
+    fn other_mutable_fn(a: u32, b: u32) -> u32 {
+        a + b
+    }
+
+    #[test]
+    fn test() {
+        assert_eq!(5, mutable_fn(2, 3));
+        assert_eq!(5, other_mutable_fn(2, 3));
+    }
+}

--- a/tests/ui/mutation/filter/filter_by_def.stdout
+++ b/tests/ui/mutation/filter/filter_by_def.stdout
@@ -1,0 +1,48 @@
+built call graph with depth of 2
+reached 66.67% of functions from tests (2 out of 3 functions)
+filtered to 50.00% of functions (1 out of 2 functions)
+
+@@@ targets @@@
+
+tests -(0)-> inner::mutable_fn at tests/ui/mutation/filter/filter_by_def.rs:16:5: 16:41 (#0)
+  (0) inner::test
+
+targets: 1 total; 1 safe; 0 unsafe (0 tainted)
+
+generated 4 mutations in 33.33% of functions (1 out of 3 functions)
+found 6 conflicts (6 excluding unsafe mutations), 0 compatibilities
+
+@@@ mutations @@@
+
+1: [arg_default_shadow] ignore `a` argument by shadowing it with `Default::default()` in inner::mutable_fn at tests/ui/mutation/filter/filter_by_def.rs:16:19: 16:25
+  <-(0)- inner::test
+
+2: [arg_default_shadow] ignore `b` argument by shadowing it with `Default::default()` in inner::mutable_fn at tests/ui/mutation/filter/filter_by_def.rs:16:27: 16:33
+  <-(0)- inner::test
+
+3: [math_op_add_mul_swap] swap operator `+` for `*` in inner::mutable_fn at tests/ui/mutation/filter/filter_by_def.rs:17:9: 17:14
+  <-(0)- inner::test
+
+4: [math_op_add_sub_swap] swap operator `+` for `-` in inner::mutable_fn at tests/ui/mutation/filter/filter_by_def.rs:17:9: 17:14
+  <-(0)- inner::test
+
+       arg_default_shadow: 50.00%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+       bit_op_or_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_xor_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    bit_op_shift_dir_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      bit_op_xor_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         bool_expr_negate:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+              call_delete:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+call_value_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      continue_break_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+             eq_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+   logical_op_and_or_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_mul_swap: 25.00%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+     math_op_add_sub_swap: 25.00%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+     math_op_div_rem_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_mul_div_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         range_limit_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    relational_op_eq_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     relational_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+
+4 mutations; 4 safe; 0 unsafe (0 tainted)

--- a/tests/ui/mutation/filter/filter_by_def_in_inherent_impl.rs
+++ b/tests/ui/mutation/filter/filter_by_def_in_inherent_impl.rs
@@ -1,0 +1,24 @@
+//@ print-targets
+//@ print-mutations
+//@ stdout
+//@ stderr: empty
+//@ mutest-flags: -v --filter-mutations=def:Vec2::len
+
+#[derive(Copy, Clone)]
+struct Vec2(f64, f64);
+
+impl Vec2 {
+    fn dot(self, other: Vec2) -> f64 {
+        (self.0 * other.0) + (self.1 * other.1)
+    }
+
+    fn len(self) -> f64 {
+        f64::sqrt(self.dot(self))
+    }
+}
+
+#[test]
+fn test_vec2() {
+    assert_eq!(0.0, Vec2(0.0, 0.0).dot(Vec2(0.0, 0.0)));
+    assert_eq!(0.0, Vec2(0.0, 0.0).len());
+}

--- a/tests/ui/mutation/filter/filter_by_def_in_inherent_impl.stdout
+++ b/tests/ui/mutation/filter/filter_by_def_in_inherent_impl.stdout
@@ -1,0 +1,48 @@
+built call graph with depth of 3
+reached 66.67% of functions from tests (2 out of 3 functions)
+filtered to 50.00% of functions (1 out of 2 functions)
+
+@@@ targets @@@
+
+tests -(0)-> Vec2::len at tests/ui/mutation/filter/filter_by_def_in_inherent_impl.rs:15:5: 15:24 (#0)
+  (0) test_vec2
+
+targets: 1 total; 1 safe; 0 unsafe (0 tainted)
+
+generated 4 mutations in 33.33% of functions (1 out of 3 functions)
+found 6 conflicts (6 excluding unsafe mutations), 0 compatibilities
+
+@@@ mutations @@@
+
+1: [call_delete] delete call to `std::f64::<impl f64>::sqrt` and replace it with `Default::default()` in Vec2::len at tests/ui/mutation/filter/filter_by_def_in_inherent_impl.rs:16:9: 16:34
+  <-(0)- test_vec2
+
+2: [call_value_default_shadow] ignore return value of call to `std::f64::<impl f64>::sqrt` by shadowing it with `Default::default()` in Vec2::len at tests/ui/mutation/filter/filter_by_def_in_inherent_impl.rs:16:9: 16:34
+  <-(0)- test_vec2
+
+3: [call_delete] delete call to `Vec2::dot` and replace it with `Default::default()` in Vec2::len at tests/ui/mutation/filter/filter_by_def_in_inherent_impl.rs:16:19: 16:33
+  <-(0)- test_vec2
+
+4: [call_value_default_shadow] ignore return value of call to `Vec2::dot` by shadowing it with `Default::default()` in Vec2::len at tests/ui/mutation/filter/filter_by_def_in_inherent_impl.rs:16:19: 16:33
+  <-(0)- test_vec2
+
+       arg_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_xor_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    bit_op_shift_dir_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      bit_op_xor_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         bool_expr_negate:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+              call_delete: 50.00%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+call_value_default_shadow: 50.00%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+      continue_break_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+             eq_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+   logical_op_and_or_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_mul_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_sub_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_div_rem_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_mul_div_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         range_limit_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    relational_op_eq_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     relational_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+
+4 mutations; 4 safe; 0 unsafe (0 tainted)

--- a/tests/ui/mutation/filter/filter_by_def_in_trait_impl.rs
+++ b/tests/ui/mutation/filter/filter_by_def_in_trait_impl.rs
@@ -1,0 +1,32 @@
+//@ print-targets
+//@ print-mutations
+//@ stdout
+//@ stderr: empty
+//@ mutest-flags: -v "--filter-mutations=def:<Vec2 as std::ops::Add>::add"
+
+use std::ops::{Add, Sub};
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+struct Vec2(f64, f64);
+
+impl Add for Vec2 {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self(self.0 + other.0, self.1 + other.1)
+    }
+}
+
+impl Sub for Vec2 {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        Self(self.0 - other.0, self.1 - other.1)
+    }
+}
+
+#[test]
+fn test_vec2() {
+    assert_eq!(Vec2(0.0, 0.0), Vec2(0.0, 0.0) + Vec2(0.0, 0.0));
+    assert_eq!(Vec2(0.0, 0.0), Vec2(0.0, 0.0) - Vec2(0.0, 0.0));
+}

--- a/tests/ui/mutation/filter/filter_by_def_in_trait_impl.stdout
+++ b/tests/ui/mutation/filter/filter_by_def_in_trait_impl.stdout
@@ -1,0 +1,48 @@
+built call graph with depth of 2
+reached 60.00% of functions from tests (3 out of 5 functions)
+filtered to 33.33% of functions (1 out of 3 functions)
+
+@@@ targets @@@
+
+tests -(0)-> <Vec2 as std::ops::Add>::add at tests/ui/mutation/filter/filter_by_def_in_trait_impl.rs:15:5: 15:38 (#0)
+  (0) test_vec2
+
+targets: 1 total; 1 safe; 0 unsafe (0 tainted)
+
+generated 4 mutations in 20.00% of functions (1 out of 5 functions)
+found 6 conflicts (6 excluding unsafe mutations), 0 compatibilities
+
+@@@ mutations @@@
+
+1: [math_op_add_mul_swap] swap operator `+` for `*` in <Vec2 as std::ops::Add>::add at tests/ui/mutation/filter/filter_by_def_in_trait_impl.rs:16:14: 16:30
+  <-(0)- test_vec2
+
+2: [math_op_add_sub_swap] swap operator `+` for `-` in <Vec2 as std::ops::Add>::add at tests/ui/mutation/filter/filter_by_def_in_trait_impl.rs:16:14: 16:30
+  <-(0)- test_vec2
+
+3: [math_op_add_mul_swap] swap operator `+` for `*` in <Vec2 as std::ops::Add>::add at tests/ui/mutation/filter/filter_by_def_in_trait_impl.rs:16:32: 16:48
+  <-(0)- test_vec2
+
+4: [math_op_add_sub_swap] swap operator `+` for `-` in <Vec2 as std::ops::Add>::add at tests/ui/mutation/filter/filter_by_def_in_trait_impl.rs:16:32: 16:48
+  <-(0)- test_vec2
+
+       arg_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_xor_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    bit_op_shift_dir_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      bit_op_xor_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         bool_expr_negate:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+              call_delete:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+call_value_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      continue_break_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+             eq_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+   logical_op_and_or_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_mul_swap: 50.00%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+     math_op_add_sub_swap: 50.00%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+     math_op_div_rem_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_mul_div_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         range_limit_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    relational_op_eq_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     relational_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+
+4 mutations; 4 safe; 0 unsafe (0 tainted)

--- a/tests/ui/mutation/filter/filter_by_file.rs
+++ b/tests/ui/mutation/filter/filter_by_file.rs
@@ -1,0 +1,19 @@
+//@ print-targets
+//@ print-mutations
+//@ stdout
+//@ stderr: empty
+//@ mutest-flags: -v --filter-mutations=file:tests/ui/mutation/filter/filter_by_file.rs
+
+fn mutable_fn(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+fn other_mutable_fn(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[test]
+fn test() {
+    assert_eq!(5, mutable_fn(2, 3));
+    assert_eq!(5, other_mutable_fn(2, 3));
+}

--- a/tests/ui/mutation/filter/filter_by_file.stdout
+++ b/tests/ui/mutation/filter/filter_by_file.stdout
@@ -1,0 +1,63 @@
+built call graph with depth of 2
+reached 100.00% of functions from tests (2 out of 2 functions)
+filtered to 100.00% of functions (2 out of 2 functions)
+
+@@@ targets @@@
+
+tests -(0)-> mutable_fn at tests/ui/mutation/filter/filter_by_file.rs:7:1: 7:37 (#0)
+  (0) test
+
+tests -(0)-> other_mutable_fn at tests/ui/mutation/filter/filter_by_file.rs:11:1: 11:43 (#0)
+  (0) test
+
+targets: 2 total; 2 safe; 0 unsafe (0 tainted)
+
+generated 8 mutations in 100.00% of functions (2 out of 2 functions)
+found 28 conflicts (28 excluding unsafe mutations), 0 compatibilities
+
+@@@ mutations @@@
+
+1: [arg_default_shadow] ignore `a` argument by shadowing it with `Default::default()` in mutable_fn at tests/ui/mutation/filter/filter_by_file.rs:7:15: 7:21
+  <-(0)- test
+
+2: [arg_default_shadow] ignore `b` argument by shadowing it with `Default::default()` in mutable_fn at tests/ui/mutation/filter/filter_by_file.rs:7:23: 7:29
+  <-(0)- test
+
+3: [math_op_add_mul_swap] swap operator `+` for `*` in mutable_fn at tests/ui/mutation/filter/filter_by_file.rs:8:5: 8:10
+  <-(0)- test
+
+4: [math_op_add_sub_swap] swap operator `+` for `-` in mutable_fn at tests/ui/mutation/filter/filter_by_file.rs:8:5: 8:10
+  <-(0)- test
+
+5: [arg_default_shadow] ignore `a` argument by shadowing it with `Default::default()` in other_mutable_fn at tests/ui/mutation/filter/filter_by_file.rs:11:21: 11:27
+  <-(0)- test
+
+6: [arg_default_shadow] ignore `b` argument by shadowing it with `Default::default()` in other_mutable_fn at tests/ui/mutation/filter/filter_by_file.rs:11:29: 11:35
+  <-(0)- test
+
+7: [math_op_add_mul_swap] swap operator `+` for `*` in other_mutable_fn at tests/ui/mutation/filter/filter_by_file.rs:12:5: 12:10
+  <-(0)- test
+
+8: [math_op_add_sub_swap] swap operator `+` for `-` in other_mutable_fn at tests/ui/mutation/filter/filter_by_file.rs:12:5: 12:10
+  <-(0)- test
+
+       arg_default_shadow: 50.00%. 4 mutations; 4 safe; 0 unsafe (0 tainted)
+       bit_op_or_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_xor_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    bit_op_shift_dir_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      bit_op_xor_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         bool_expr_negate:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+              call_delete:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+call_value_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      continue_break_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+             eq_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+   logical_op_and_or_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_mul_swap: 25.00%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+     math_op_add_sub_swap: 25.00%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+     math_op_div_rem_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_mul_div_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         range_limit_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    relational_op_eq_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     relational_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+
+8 mutations; 8 safe; 0 unsafe (0 tainted)

--- a/tests/ui/mutation/filter/filter_by_file_line.rs
+++ b/tests/ui/mutation/filter/filter_by_file_line.rs
@@ -1,0 +1,20 @@
+//@ print-targets
+//@ print-mutations
+//@ stdout
+//@ stderr: empty
+//@ mutest-flags: -v --filter-mutations=file:tests/ui/mutation/filter/filter_by_file_line.rs:9
+
+fn mutable_fn(a: u32, b: u32) -> u32 {
+    if a == b { return 0; }
+    a + b
+}
+
+fn other_mutable_fn(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[test]
+fn test() {
+    assert_eq!(5, mutable_fn(2, 3));
+    assert_eq!(5, other_mutable_fn(2, 3));
+}

--- a/tests/ui/mutation/filter/filter_by_file_line.stdout
+++ b/tests/ui/mutation/filter/filter_by_file_line.stdout
@@ -1,0 +1,42 @@
+built call graph with depth of 2
+reached 100.00% of functions from tests (2 out of 2 functions)
+filtered to 50.00% of functions (1 out of 2 functions)
+
+@@@ targets @@@
+
+tests -(0)-> mutable_fn at tests/ui/mutation/filter/filter_by_file_line.rs:7:1: 7:37 (#0)
+  (0) test
+
+targets: 1 total; 1 safe; 0 unsafe (0 tainted)
+
+generated 2 mutations in 50.00% of functions (1 out of 2 functions)
+found 1 conflicts (1 excluding unsafe mutations), 0 compatibilities
+
+@@@ mutations @@@
+
+1: [math_op_add_mul_swap] swap operator `+` for `*` in mutable_fn at tests/ui/mutation/filter/filter_by_file_line.rs:9:5: 9:10
+  <-(0)- test
+
+2: [math_op_add_sub_swap] swap operator `+` for `-` in mutable_fn at tests/ui/mutation/filter/filter_by_file_line.rs:9:5: 9:10
+  <-(0)- test
+
+       arg_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_xor_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    bit_op_shift_dir_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      bit_op_xor_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         bool_expr_negate:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+              call_delete:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+call_value_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      continue_break_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+             eq_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+   logical_op_and_or_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_mul_swap: 50.00%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+     math_op_add_sub_swap: 50.00%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+     math_op_div_rem_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_mul_div_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         range_limit_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    relational_op_eq_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     relational_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+
+2 mutations; 2 safe; 0 unsafe (0 tainted)

--- a/tests/ui/mutation/filter/filter_by_file_line_range.rs
+++ b/tests/ui/mutation/filter/filter_by_file_line_range.rs
@@ -1,0 +1,21 @@
+//@ print-targets
+//@ print-mutations
+//@ stdout
+//@ stderr: empty
+//@ mutest-flags: -v --filter-mutations=file:tests/ui/mutation/filter/filter_by_file_line_range.rs:8:9
+
+fn mutable_fn(a: i32, b: i32) -> i32 {
+    if a == 0 { return -b; }
+    if b == 0 { return -a; }
+    a + b
+}
+
+fn other_mutable_fn(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[test]
+fn test() {
+    assert_eq!(5, mutable_fn(2, 3));
+    assert_eq!(5, other_mutable_fn(2, 3));
+}

--- a/tests/ui/mutation/filter/filter_by_file_line_range.stdout
+++ b/tests/ui/mutation/filter/filter_by_file_line_range.stdout
@@ -1,0 +1,48 @@
+built call graph with depth of 2
+reached 100.00% of functions from tests (2 out of 2 functions)
+filtered to 50.00% of functions (1 out of 2 functions)
+
+@@@ targets @@@
+
+tests -(0)-> mutable_fn at tests/ui/mutation/filter/filter_by_file_line_range.rs:7:1: 7:37 (#0)
+  (0) test
+
+targets: 1 total; 1 safe; 0 unsafe (0 tainted)
+
+generated 4 mutations in 50.00% of functions (1 out of 2 functions)
+found 6 conflicts (6 excluding unsafe mutations), 0 compatibilities
+
+@@@ mutations @@@
+
+1: [bool_expr_negate] negate boolean expression in mutable_fn at tests/ui/mutation/filter/filter_by_file_line_range.rs:8:8: 8:14
+  <-(0)- test
+
+2: [eq_op_invert] invert equality operator `==` to `!=` in mutable_fn at tests/ui/mutation/filter/filter_by_file_line_range.rs:8:8: 8:14
+  <-(0)- test
+
+3: [bool_expr_negate] negate boolean expression in mutable_fn at tests/ui/mutation/filter/filter_by_file_line_range.rs:9:8: 9:14
+  <-(0)- test
+
+4: [eq_op_invert] invert equality operator `==` to `!=` in mutable_fn at tests/ui/mutation/filter/filter_by_file_line_range.rs:9:8: 9:14
+  <-(0)- test
+
+       arg_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_xor_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    bit_op_shift_dir_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      bit_op_xor_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         bool_expr_negate: 50.00%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+              call_delete:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+call_value_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      continue_break_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+             eq_op_invert: 50.00%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+   logical_op_and_or_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_mul_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_sub_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_div_rem_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_mul_div_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         range_limit_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    relational_op_eq_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     relational_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+
+4 mutations; 4 safe; 0 unsafe (0 tainted)

--- a/tests/ui/mutation/filter/filters_are_additive.rs
+++ b/tests/ui/mutation/filter/filters_are_additive.rs
@@ -1,0 +1,20 @@
+//@ print-targets
+//@ print-mutations
+//@ stdout
+//@ stderr: empty
+//@ mutest-flags: -v --filter-mutations=file:tests/ui/mutation/filter/filters_are_additive.rs:8,def:other_mutable_fn
+
+fn mutable_fn(a: u32, b: u32) -> u32 {
+    if a == b { return 0; }
+    a + b
+}
+
+fn other_mutable_fn(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[test]
+fn test() {
+    assert_eq!(5, mutable_fn(2, 3));
+    assert_eq!(5, other_mutable_fn(2, 3));
+}

--- a/tests/ui/mutation/filter/filters_are_additive.stdout
+++ b/tests/ui/mutation/filter/filters_are_additive.stdout
@@ -1,0 +1,57 @@
+built call graph with depth of 2
+reached 100.00% of functions from tests (2 out of 2 functions)
+filtered to 100.00% of functions (2 out of 2 functions)
+
+@@@ targets @@@
+
+tests -(0)-> mutable_fn at tests/ui/mutation/filter/filters_are_additive.rs:7:1: 7:37 (#0)
+  (0) test
+
+tests -(0)-> other_mutable_fn at tests/ui/mutation/filter/filters_are_additive.rs:12:1: 12:43 (#0)
+  (0) test
+
+targets: 2 total; 2 safe; 0 unsafe (0 tainted)
+
+generated 6 mutations in 100.00% of functions (2 out of 2 functions)
+found 15 conflicts (15 excluding unsafe mutations), 0 compatibilities
+
+@@@ mutations @@@
+
+1: [bool_expr_negate] negate boolean expression in mutable_fn at tests/ui/mutation/filter/filters_are_additive.rs:8:8: 8:14
+  <-(0)- test
+
+2: [eq_op_invert] invert equality operator `==` to `!=` in mutable_fn at tests/ui/mutation/filter/filters_are_additive.rs:8:8: 8:14
+  <-(0)- test
+
+3: [arg_default_shadow] ignore `a` argument by shadowing it with `Default::default()` in other_mutable_fn at tests/ui/mutation/filter/filters_are_additive.rs:12:21: 12:27
+  <-(0)- test
+
+4: [arg_default_shadow] ignore `b` argument by shadowing it with `Default::default()` in other_mutable_fn at tests/ui/mutation/filter/filters_are_additive.rs:12:29: 12:35
+  <-(0)- test
+
+5: [math_op_add_mul_swap] swap operator `+` for `*` in other_mutable_fn at tests/ui/mutation/filter/filters_are_additive.rs:13:5: 13:10
+  <-(0)- test
+
+6: [math_op_add_sub_swap] swap operator `+` for `-` in other_mutable_fn at tests/ui/mutation/filter/filters_are_additive.rs:13:5: 13:10
+  <-(0)- test
+
+       arg_default_shadow: 33.33%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+       bit_op_or_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_xor_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    bit_op_shift_dir_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      bit_op_xor_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         bool_expr_negate: 16.67%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+              call_delete:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+call_value_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      continue_break_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+             eq_op_invert: 16.67%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+   logical_op_and_or_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_mul_swap: 16.67%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+     math_op_add_sub_swap: 16.67%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+     math_op_div_rem_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_mul_div_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         range_limit_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    relational_op_eq_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     relational_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+
+6 mutations; 6 safe; 0 unsafe (0 tainted)

--- a/tests/ui/mutation/filter/ignore_unknown_defs.rs
+++ b/tests/ui/mutation/filter/ignore_unknown_defs.rs
@@ -1,0 +1,14 @@
+//@ print-targets
+//@ print-mutations
+//@ stdout
+//@ stderr: empty
+//@ mutest-flags: -v --filter-mutations=def:other_mutable_fn
+
+fn mutable_fn(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[test]
+fn test() {
+    assert_eq!(5, mutable_fn(2, 3));
+}

--- a/tests/ui/mutation/filter/ignore_unknown_defs.stdout
+++ b/tests/ui/mutation/filter/ignore_unknown_defs.stdout
@@ -1,0 +1,33 @@
+built call graph with depth of 2
+reached 100.00% of functions from tests (1 out of 1 functions)
+filtered to 0.00% of functions (0 out of 1 functions)
+
+@@@ targets @@@
+
+targets: 0 total; 0 safe; 0 unsafe (0 tainted)
+
+generated 0 mutations in 0.00% of functions (0 out of 1 functions)
+found 0 conflicts (0 excluding unsafe mutations), 0 compatibilities
+
+@@@ mutations @@@
+
+       arg_default_shadow:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_and_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_xor_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    bit_op_shift_dir_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      bit_op_xor_and_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         bool_expr_negate:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+              call_delete:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+call_value_default_shadow:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      continue_break_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+             eq_op_invert:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+   logical_op_and_or_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_mul_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_sub_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_div_rem_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_mul_div_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         range_limit_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    relational_op_eq_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     relational_op_invert:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+
+0 mutations; 0 safe; 0 unsafe (0 tainted)

--- a/tests/ui/mutation/filter/ignore_unknown_files.rs
+++ b/tests/ui/mutation/filter/ignore_unknown_files.rs
@@ -1,0 +1,14 @@
+//@ print-targets
+//@ print-mutations
+//@ stdout
+//@ stderr: empty
+//@ mutest-flags: -v --filter-mutations=file:/dummy/this_file_should_never_exist.rs:21
+
+fn mutable_fn(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[test]
+fn test() {
+    assert_eq!(5, mutable_fn(2, 3));
+}

--- a/tests/ui/mutation/filter/ignore_unknown_files.stdout
+++ b/tests/ui/mutation/filter/ignore_unknown_files.stdout
@@ -1,0 +1,33 @@
+built call graph with depth of 2
+reached 100.00% of functions from tests (1 out of 1 functions)
+filtered to 0.00% of functions (0 out of 1 functions)
+
+@@@ targets @@@
+
+targets: 0 total; 0 safe; 0 unsafe (0 tainted)
+
+generated 0 mutations in 0.00% of functions (0 out of 1 functions)
+found 0 conflicts (0 excluding unsafe mutations), 0 compatibilities
+
+@@@ mutations @@@
+
+       arg_default_shadow:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_and_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_xor_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    bit_op_shift_dir_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      bit_op_xor_and_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         bool_expr_negate:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+              call_delete:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+call_value_default_shadow:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      continue_break_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+             eq_op_invert:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+   logical_op_and_or_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_mul_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_sub_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_div_rem_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_mul_div_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         range_limit_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    relational_op_eq_swap:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     relational_op_invert:   NaN%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+
+0 mutations; 0 safe; 0 unsafe (0 tainted)

--- a/tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.rs
+++ b/tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.rs
@@ -1,0 +1,21 @@
+//@ print-targets
+//@ print-mutations
+//@ stdout
+//@ stderr: empty
+//@ mutest-flags: -v --filter-mutations=file:tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.rs:12:13
+
+fn other_mutable_fn(a: bool, b: bool) -> bool {
+    a || b
+}
+
+fn mutable_fn(a: u32, b: u32) -> bool {
+    other_mutable_fn(
+        a == 0,
+        b >= 1,
+    )
+}
+
+#[test]
+fn test() {
+    assert!(mutable_fn(0, 1));
+}

--- a/tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.stdout
+++ b/tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.stdout
@@ -1,0 +1,51 @@
+built call graph with depth of 2
+reached 100.00% of functions from tests (2 out of 2 functions)
+filtered to 50.00% of functions (1 out of 2 functions)
+
+@@@ targets @@@
+
+tests -(0)-> mutable_fn at tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.rs:11:1: 11:38 (#0)
+  (0) test
+
+targets: 1 total; 1 safe; 0 unsafe (0 tainted)
+
+generated 5 mutations in 50.00% of functions (1 out of 2 functions)
+found 10 conflicts (10 excluding unsafe mutations), 0 compatibilities
+
+@@@ mutations @@@
+
+1: [bool_expr_negate] negate boolean expression in mutable_fn at tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.rs:12:5: 15:6
+  <-(0)- test
+
+2: [call_delete] delete call to `other_mutable_fn` and replace it with `Default::default()` in mutable_fn at tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.rs:12:5: 15:6
+  <-(0)- test
+
+3: [call_value_default_shadow] ignore return value of call to `other_mutable_fn` by shadowing it with `Default::default()` in mutable_fn at tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.rs:12:5: 15:6
+  <-(0)- test
+
+4: [bool_expr_negate] negate boolean expression in mutable_fn at tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.rs:13:9: 13:15
+  <-(0)- test
+
+5: [eq_op_invert] invert equality operator `==` to `!=` in mutable_fn at tests/ui/mutation/filter/mutate_exprs_partially_in_file_line_ranges.rs:13:9: 13:15
+  <-(0)- test
+
+       arg_default_shadow:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+       bit_op_or_xor_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    bit_op_shift_dir_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+      bit_op_xor_and_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         bool_expr_negate: 40.00%. 2 mutations; 2 safe; 0 unsafe (0 tainted)
+              call_delete: 20.00%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+call_value_default_shadow: 20.00%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+      continue_break_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+             eq_op_invert: 20.00%. 1 mutations; 1 safe; 0 unsafe (0 tainted)
+   logical_op_and_or_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_mul_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_add_sub_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_div_rem_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     math_op_mul_div_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+         range_limit_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+    relational_op_eq_swap:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+     relational_op_invert:  0.00%. 0 mutations; 0 safe; 0 unsafe (0 tainted)
+
+5 mutations; 5 safe; 0 unsafe (0 tainted)


### PR DESCRIPTION
This PR adds a `--filter-mutations` option to apply one or more filters for mutation generation based on their location within source code. The idea for a way of filtering mutations to specific areas of source code was suggested by @seam345 for targeting repeated invocations for iterative test development. This change adds the following filters:
* `--filter-mutations=def:rust::path::to::Item::function`: Only mutate the specified definition based on its full, canonical Rust item path (without the root crate specifier for the current crate). This includes support for inherent associated items (e.g., `--filter-mutations=def:path::to::Struct::function`), and trait associated items through Rust's qualified self path syntax (e.g., `--filter-mutations=def:<Struct as Trait>::function`).
* `--filter-mutations=file:path/to/file.rs`: Only mutate the specified file. The file path must be in the form recognized by rustc, which typically is relative to the workspace root directory for Cargo workspace crates, relative to the current working directory for non-Cargo crates, and the absolute path for any dependency crate, even workspace-local ones.
* `--filter-mutations=file:path/to/file.rs:21:25`: Only mutate the specified line range in the specified file. Line numbering is as recognized by rustc and text editors, and the range is inclusive of both the start and end lines.
* `--filter-mutations=file:path/to/file.rs:21`: Only mutate the specified line in the specified file. This is effectively a shorthand for the above with a single line range, i.e., `file:<PATH>:<N>:<N>`.

Multiple filters can be combined in an additive manner (separated by `,` on the command line), with each matching different areas of the source code. No wildcard syntax is currently supported for any filters.