### PR TITLE
feat: Restructure mutest-driver and cargo-mutest CLIs

### DIFF
--- a/cargo-mutest/src/main.rs
+++ b/cargo-mutest/src/main.rs
@@ -131,8 +131,10 @@ fn main() {
         .arg(clap::arg!(--profile [PROFILE] "Build artifacts with the specified profile."))
         .arg(clap::arg!(--"target-dir" [TARGET_DIR] "Directory for all generated artifacts.").value_parser(clap::value_parser!(PathBuf)))
         .next_help_heading("Manifest Options")
-        .arg(clap::arg!(--"manifest-path" [MANIFEST_PATH] "Path to Cargo.toml."))
+        .arg(clap::arg!(--"manifest-path" [MANIFEST_PATH] "Path to `Cargo.toml`."))
+        .arg(clap::arg!(--locked "Assert that `Cargo.lock` will remain unchanged."))
         .arg(clap::arg!(--offline "Run without accessing the network."))
+        .arg(clap::arg!(--frozen "Equivalent to specifying both `--locked` and `--offline`."))
         .after_help(color_print::cstr!("Run `<bright-cyan,bold>cargo mutest run -h</>` to display additional options that can be specified for the running test harness."))
         .after_long_help(color_print::cstr!("Run `<bright-cyan,bold>cargo mutest help run</>` to display additional options that can be specified for the running test harness."))
         .get_matches_from(&args);
@@ -390,9 +392,17 @@ fn main() {
         cmd.args(["--lib", "--bins", "--examples", "--tests"]);
     }
 
+    if matches.get_flag("locked") {
+        cmd.arg("--locked");
+        strip_arg(&mut mutest_args, false, None, Some("locked"));
+    }
     if matches.get_flag("offline") {
         cmd.arg("--offline");
         strip_arg(&mut mutest_args, false, None, Some("offline"));
+    }
+    if matches.get_flag("frozen") {
+        cmd.arg("--frozen");
+        strip_arg(&mut mutest_args, false, None, Some("frozen"));
     }
 
     let mut path = env::current_exe().expect("current executable path invalid");

--- a/cargo-mutest/src/main.rs
+++ b/cargo-mutest/src/main.rs
@@ -88,9 +88,10 @@ fn main() {
         .bin_name("cargo mutest")
         .no_binary_name(true)
         .about("Mutation testing tools for Rust")
+        .subcommand_required(true)
+        .arg_required_else_help(true)
         // Subcommands
         .subcommand(clap::Command::new("run")
-            .display_order(0)
             .about("Build and run the test harness.")
             .arg(clap::arg!(-i --inspect [INSPECT_OPTS] "Inspect mutations after evaluation. Options may be specified in the form `--inspect=[open][:<PORT>]`.").num_args(0..=1).require_equals(true).display_order(100))
             // Evaluation-related Arguments
@@ -106,6 +107,13 @@ fn main() {
             // Passed arguments
             .arg(clap::Arg::new("PASSED_ARGS").trailing_var_arg(true).allow_hyphen_values(true))
         )
+        .subcommand(clap::Command::new("build")
+            .about("Build the test harness.")
+        )
+        .subcommand(clap::Command::new("print")
+            .about("Print information about analysis, without building.")
+        )
+        .arg(clap::arg!(--"no-write-json" "Do not write JSON metadata files."))
         // Cargo options.
         .arg(clap::arg!(--color [WHEN] "Output coloring."))
         .next_help_heading("Package Selection")
@@ -142,9 +150,9 @@ fn main() {
     let embedded = matches.get_flag("Zembedded");
     let parallel_mutants = matches.get_flag("parallel-mutants");
 
-    let (cargo_subcommand, cargo_args, mutest_driver_subcommand, passed_args, inspect_opts): (_, &[&str], _, _, _) = match matches.subcommand() {
-        Some(("print", _)) => ("check", &["--profile", "test"], "print", None, None),
-        Some(("build", _)) => ("test", &["--no-run"], "build", None, None),
+    let (cargo_subcommand, cargo_args, mut mutest_driver_outputs, passed_args, inspect_opts): (_, &[&str], _, _, _) = match matches.subcommand() {
+        Some(("print", _)) => ("check", &["--profile", "test"], vec!["info"], None, None),
+        Some(("build", _)) => ("test", &["--no-run"], vec!["info", "test-bin"], None, None),
         Some(("run", matches)) => {
             let mut passed_args = matches.get_many::<String>("PASSED_ARGS").unwrap_or_default().map(ToOwned::to_owned).collect::<Vec<_>>();
 
@@ -196,7 +204,7 @@ fn main() {
 
             if matches.get_flag("Zwrite-json-eval-stream") { passed_args.push("--Zwrite-json-eval-stream".to_owned()); }
 
-            ("test", &["--no-fail-fast"], "build", Some(passed_args), inspect_opts)
+            ("test", &["--no-fail-fast"], vec!["info", "test-bin"], Some(passed_args), inspect_opts)
         }
         _ => unreachable!(),
     };
@@ -259,7 +267,7 @@ fn main() {
 
     let mut mutest_args = args.clone();
     let i = mutest_args.iter().position(|arg| matches.subcommand_name().is_some_and(|subcommand| arg == subcommand)).expect("subcommand not found in args");
-    mutest_args.splice(i.., [mutest_driver_subcommand.to_owned()]);
+    mutest_args.splice(i.., []);
 
     if let Some(color) = matches.get_one::<String>("color") {
         cmd.args(["--color", color]);
@@ -409,6 +417,13 @@ fn main() {
     path.set_file_name("mutest-driver");
     if cfg!(windows) { path.set_extension("exe"); }
     cmd.env("RUSTC_WORKSPACE_WRAPPER", path);
+
+    if matches.get_flag("no-write-json") {
+        strip_arg(&mut mutest_args, false, None, Some("no-write-json"));
+    } else {
+        mutest_driver_outputs.push("metadata");
+    }
+    mutest_args.push(format!("--emit={}", mutest_driver_outputs.join(",")));
 
     cmd.env("MUTEST_ENCODED_ARGS", mutest_args.join("\x1F"));
 

--- a/cargo-mutest/src/main.rs
+++ b/cargo-mutest/src/main.rs
@@ -46,9 +46,9 @@ fn test_strip_arg() {
     strip_arg(&mut args, true, None, Some("features"));
     assert_eq!(&[] as &[String], &args[..]);
 
-    let mut args = vec!["--features=all".to_owned(), "--json-out-root-dir=target/mutest/json".to_owned(), "--print=code".to_owned()];
+    let mut args = vec!["--features=all".to_owned(), "--metadata-out-root-dir=target/mutest/json".to_owned(), "--print=code".to_owned()];
     strip_arg(&mut args, true, None, Some("features"));
-    assert_eq!(&["--json-out-root-dir=target/mutest/json".to_owned(), "--print=code".to_owned()] as &[String], &args[..]);
+    assert_eq!(&["--metadata-out-root-dir=target/mutest/json".to_owned(), "--print=code".to_owned()] as &[String], &args[..]);
 }
 
 mod run_isolate {
@@ -103,7 +103,7 @@ fn main() {
             // Printing-related Arguments
             .arg(clap::arg!(--print [PRINT] "Print additional information during mutation evaluation. Multiple may be specified, separated by commas.").value_delimiter(',').value_parser(run_print::possible_values()).display_order(101))
             // Experimental Flags
-            .arg(clap::arg!(--"Zwrite-json-eval-stream" "Write JSONL stream file into JSON output directory specified by `--json-out-root-dir`.").display_order(500))
+            .arg(clap::arg!(--"Zwrite-json-eval-stream" "Write JSONL stream file into JSON output directory specified by `--metadata-out-root-dir`.").display_order(500))
             // Passed arguments
             .arg(clap::Arg::new("PASSED_ARGS").trailing_var_arg(true).allow_hyphen_values(true))
         )
@@ -113,7 +113,7 @@ fn main() {
         .subcommand(clap::Command::new("print")
             .about("Print information about analysis, without building.")
         )
-        .arg(clap::arg!(--"no-write-json" "Do not write JSON metadata files."))
+        .arg(clap::arg!(--"no-emit-metadata" "Do not write JSON metadata files."))
         // Cargo options.
         .arg(clap::arg!(--color [WHEN] "Output coloring."))
         .next_help_heading("Package Selection")
@@ -418,8 +418,8 @@ fn main() {
     if cfg!(windows) { path.set_extension("exe"); }
     cmd.env("RUSTC_WORKSPACE_WRAPPER", path);
 
-    if matches.get_flag("no-write-json") {
-        strip_arg(&mut mutest_args, false, None, Some("no-write-json"));
+    if matches.get_flag("no-emit-metadata") {
+        strip_arg(&mut mutest_args, false, None, Some("no-emit-metadata"));
     } else {
         mutest_driver_outputs.push("metadata");
     }
@@ -431,14 +431,14 @@ fn main() {
         cmd.arg("--");
         cmd.args((0..matches.get_count("verbose")).map(|_| "-v"));
         if matches.get_flag("timings") { cmd.arg("--timings"); }
-        if !matches.get_flag("no-write-json") {
-            let out_dir = matches.get_one::<PathBuf>("json-out-root-dir").cloned().unwrap_or_else(|| target_dir.join("json"));
+        if !matches.get_flag("no-emit-metadata") {
+            let out_dir = matches.get_one::<PathBuf>("metadata-out-root-dir").cloned().unwrap_or_else(|| target_dir.join("json"));
             fs::create_dir_all(&out_dir).expect(&format!("cannot create JSON output directory at `{}`", out_dir.display()));
             // NOTE: The out dir path passed to the generated test binary must be canonicalized,
             //       as it will likely be run under a different cwd.
             let out_dir = out_dir.canonicalize().expect("cannot canonicalize out dir path");
             let out_dir = out_dir.as_os_str().to_str().expect("non-UTF-8 path");
-            cmd.arg(format!("--json-out-root-dir={out_dir}"));
+            cmd.arg(format!("--metadata-out-root-dir={out_dir}"));
         }
         cmd.args(&passed_args);
     }
@@ -462,7 +462,7 @@ fn main() {
     // NOTE: This replicates Cargo's action message styling, including the color and justification.
     color_print::ceprintln!("<green,bold>{:>12}</> inspector", "Running");
 
-    let json_root_dir = matches.get_one::<PathBuf>("json-out-root-dir").cloned().unwrap_or_else(|| target_dir.join("json"));
+    let metadata_root_dir = matches.get_one::<PathBuf>("metadata-out-root-dir").cloned().unwrap_or_else(|| target_dir.join("json"));
 
     let mut path = env::current_exe().expect("current executable path invalid");
     path.set_file_name("mutest-inspector");
@@ -470,8 +470,8 @@ fn main() {
 
     let mut cmd = Command::new(path);
 
-    cmd.arg("--json-root-dir");
-    cmd.arg(json_root_dir);
+    cmd.arg("--metadata-root-dir");
+    cmd.arg(metadata_root_dir);
 
     if let Some(port) = port { cmd.arg(format!("--port={port}")); }
 

--- a/cargo-mutest/src/main.rs
+++ b/cargo-mutest/src/main.rs
@@ -109,8 +109,9 @@ fn main() {
         // Cargo options.
         .arg(clap::arg!(--color [WHEN] "Output coloring."))
         .next_help_heading("Package Selection")
+        .arg(clap::arg!(-p --package [PACKAGE] "Test the specified packages.").action(clap::ArgAction::Append))
         .arg(clap::arg!(--workspace "Test all packages in the workspace."))
-        .arg(clap::arg!(-p --package [PACKAGE] "Package with the target to analyze."))
+        .arg(clap::arg!(--exclude [PACKAGE] "Exclude packages from testing.").action(clap::ArgAction::Append))
         .next_help_heading("Target Selection")
         .arg(clap::arg!(--lib "Test only this package's library unit tests."))
         .arg(clap::arg!(--bin [BINARY] "Test only the specified binary. This flag may be specified multiple times.").action(clap::ArgAction::Append))
@@ -279,13 +280,17 @@ fn main() {
     }
 
     // Package selection.
+    if let Some(packages) = matches.get_many::<String>("package") {
+        for package in packages { cmd.args(["--package", package]); }
+        strip_arg(&mut mutest_args, true, Some("p"), Some("package"));
+    }
     if matches.get_flag("workspace") {
         cmd.arg("--workspace");
         strip_arg(&mut mutest_args, false, None, Some("workspace"));
     }
-    if let Some(package) = matches.get_one::<String>("package") {
-        cmd.args(["--package", package]);
-        strip_arg(&mut mutest_args, true, Some("p"), Some("package"));
+    if let Some(packages) = matches.get_many::<String>("exclude") {
+        for package in packages { cmd.args(["--exclude", package]); }
+        strip_arg(&mut mutest_args, true, None, Some("exclude"));
     }
 
     // Feature selection.
@@ -447,7 +452,8 @@ fn main() {
 
     if open {
         // NOTE: Only attempt to open a specific target if only one was selected.
-        if let Some(package) = matches.get_one::<String>("package") {
+        let mut packages_iter = matches.get_many::<String>("package").into_iter().flatten();
+        if let Some(package) = packages_iter.next() && let None = packages_iter.next() {
             if explicit_targetings_count == 1 {
                 match () {
                     _ if matches.get_flag("lib") => { cmd.arg(format!("--open={}/lib", package)); }

--- a/mutest-driver-cli/src/lib.rs
+++ b/mutest-driver-cli/src/lib.rs
@@ -72,11 +72,11 @@ pub mod mutant_batch_greedy_ordering_heuristic {
 pub mod print {
     crate::opts! { ALL, pub(crate) possible_values where
         TESTS = "tests"; ["Print list of test cases."]
-        TARGETS = "targets"; ["Print list of functions targeted for mutation at the specified depth."]
         CALL_GRAPH = "call-graph"; ["Print call graph of test cases."]
-        CONFLICT_GRAPH = "conflict-graph"; ["Print mutation conflict graph."]
-        COMPATIBILITY_GRAPH = "compatibility-graph"; ["Print mutation compatibility graph (i.e. the complement graph of the conflict graph)."]
+        TARGETS = "targets"; ["Print list of functions targeted for mutation at the specified depth."]
         MUTATIONS = "mutations"; ["Print list of generated mutations, optionally grouped into mutation batches."]
+        CONFLICT_GRAPH = "conflict-graph"; ["Print mutation conflict graph."]
+        COMPATIBILITY_GRAPH = "compatibility-graph"; ["Print mutation compatibility graph (i.e., the complement graph of the conflict graph)."]
         CODE = "code"; ["Print the generated code of the test harness."]
     }
 }

--- a/mutest-driver-cli/src/lib.rs
+++ b/mutest-driver-cli/src/lib.rs
@@ -154,7 +154,7 @@ pub fn command() -> clap::Command {
         .arg(clap::arg!(--"call-graph-non-local-calls" [CALL_GRAPH_NON_LOCAL_CALL_VIEW] "Mode to display non-local calls in the call graph.").value_parser(call_graph_non_local_call_view::possible_values()).default_value(call_graph_non_local_call_view::COLLAPSE).display_order(103))
         .arg(clap::arg!(--"call-graph-filter-entry-points" [ENTRY_POINTS] "Filter entry points to display the call graph for. Multiple may be specified, separated by commas.").value_delimiter(',').display_order(103))
         // Metadata-related Arguments
-        .arg(clap::arg!(--"json-out-root-dir" [JSON_ROOT_DIR] "Write JSON metadata files into the specified output directory. By default, JSON metadata files are written to `target/mutest/json`.").value_parser(clap::value_parser!(PathBuf)).display_order(105))
+        .arg(clap::arg!(--"metadata-out-root-dir" [METADATA_ROOT_DIR] "Write JSON metadata files into the specified output directory. By default, JSON metadata files are written to `target/mutest/json`.").value_parser(clap::value_parser!(PathBuf)).display_order(105))
         // Experimental Flags
         .arg(clap::arg!(--Zverify [VERIFY] "Perform additional checks to verify correctness and completeness. Multiple may be specified, separated by commas.").value_delimiter(',').value_parser(verify::possible_values()).display_order(500))
         .arg(clap::arg!(--Zembedded "Enable experimental support for embedded-test tests and embedded firmware generation with no_std support using a tethered embedded mutation runtime.").display_order(500))

--- a/mutest-driver-cli/src/lib.rs
+++ b/mutest-driver-cli/src/lib.rs
@@ -112,8 +112,6 @@ pub fn command() -> clap::Command {
         .name("mutest-rs")
         .version(VERSION_STR)
         .propagate_version(true)
-        .subcommand_required(true)
-        .arg_required_else_help(true)
         .disable_help_flag(true)
         .disable_version_flag(true)
         .styles({
@@ -124,15 +122,6 @@ pub fn command() -> clap::Command {
                 .literal(Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightBlue))).bold())
                 .placeholder(Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightBlue))))
         })
-        // Subcommands
-        .subcommand(clap::Command::new("print")
-            .display_order(2)
-            .about("Print information about analysis, without building.")
-        )
-        .subcommand(clap::Command::new("build")
-            .display_order(1)
-            .about("Build the test harness.")
-        )
         // Mutation-related Arguments
         .arg(clap::arg!(--safe "Avoid mutating code in contexts which contain `unsafe` blocks. [default]").display_order(111))
         .arg(clap::arg!(--cautious "Produce unsafe mutations in contexts which contain `unsafe` blocks.").display_order(112))
@@ -166,7 +155,6 @@ pub fn command() -> clap::Command {
         .arg(clap::arg!(--"call-graph-filter-entry-points" [ENTRY_POINTS] "Filter entry points to display the call graph for. Multiple may be specified, separated by commas.").value_delimiter(',').display_order(103))
         // Metadata-related Arguments
         .arg(clap::arg!(--"json-out-root-dir" [JSON_ROOT_DIR] "Write JSON metadata files into the specified output directory. By default, JSON metadata files are written to `target/mutest/json`.").value_parser(clap::value_parser!(PathBuf)).display_order(105))
-        .arg(clap::arg!(--"no-write-json" "Do not write JSON metadata files.").display_order(105))
         // Experimental Flags
         .arg(clap::arg!(--Zverify [VERIFY] "Perform additional checks to verify correctness and completeness. Multiple may be specified, separated by commas.").value_delimiter(',').value_parser(verify::possible_values()).display_order(500))
         .arg(clap::arg!(--Zembedded "Enable experimental support for embedded-test tests and embedded firmware generation with no_std support using a tethered embedded mutation runtime.").display_order(500))

--- a/mutest-driver/src/config.rs
+++ b/mutest-driver/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use mutest_emit::codegen::mutation::{Operators, UnsafeTargeting};
@@ -53,6 +54,13 @@ pub enum CargoTargetKind {
     Test,
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum OutputKind {
+    PrintInfo,
+    Metadata,
+    TestBin,
+}
+
 #[derive(Copy, Clone, Debug)]
 pub enum GraphFormat {
     Simple,
@@ -105,11 +113,6 @@ impl PrintOptions {
 #[derive(Clone, Debug)]
 pub struct WriteOptions {
     pub out_dir: PathBuf,
-}
-
-pub enum Mode {
-    Print,
-    Build,
 }
 
 pub use mutest_emit::codegen::mutation::GreedyMutationBatchingOrderingHeuristic;
@@ -169,11 +172,11 @@ pub struct Options<'op, 'm> {
     pub crate_kind: CrateKind,
     pub cargo_target_kind: Option<CargoTargetKind>,
 
-    pub mode: Mode,
+    pub outputs: BTreeSet<OutputKind>,
     pub verbosity: u8,
     pub report_timings: bool,
     pub print_opts: PrintOptions,
-    pub write_opts: Option<WriteOptions>,
+    pub write_opts: WriteOptions,
     pub unsafe_targeting: UnsafeTargeting,
     pub operators: Operators<'op, 'm>,
     pub call_graph_depth_limit: Option<usize>,

--- a/mutest-driver/src/config.rs
+++ b/mutest-driver/src/config.rs
@@ -83,10 +83,10 @@ pub struct ConflictGraphOptions {
 pub struct PrintOptions {
     pub print_headers: bool,
     pub tests: Option<()>,
-    pub mutation_targets: Option<()>,
     pub call_graph: Option<CallGraphOptions>,
-    pub conflict_graph: Option<ConflictGraphOptions>,
+    pub mutation_targets: Option<()>,
     pub mutations: Option<()>,
+    pub conflict_graph: Option<ConflictGraphOptions>,
     pub code: Option<()>,
 }
 
@@ -94,10 +94,10 @@ impl PrintOptions {
     pub fn is_empty(&self) -> bool {
         true
             && self.tests.is_none()
-            && self.mutation_targets.is_none()
             && self.call_graph.is_none()
-            && self.conflict_graph.is_none()
+            && self.mutation_targets.is_none()
             && self.mutations.is_none()
+            && self.conflict_graph.is_none()
             && self.code.is_none()
     }
 }

--- a/mutest-driver/src/inject.rs
+++ b/mutest-driver/src/inject.rs
@@ -192,8 +192,10 @@ pub fn inject_runtime_crate_and_deps(config: &Config, compiler_config: &mut Comp
         }
     }
 
-    if let Some((visible_crate_name, specialized_external_mutant_crate_compilation)) = specialized_external_mutant_crate {
-        let mut file_path = specialized_external_mutant_crate_compilation.outputs.path(OutputType::Metadata).as_path().to_owned();
+    if let Some((visible_crate_name, specialized_external_mutant_crate_compilation)) = specialized_external_mutant_crate
+        && let Some(specialized_external_mutant_crate_outputs) = &specialized_external_mutant_crate_compilation.outputs
+    {
+        let mut file_path = specialized_external_mutant_crate_outputs.path(OutputType::Metadata).as_path().to_owned();
         file_path.set_extension("rlib");
 
         let Some(extern_entry) = externs.get_mut(visible_crate_name) else {

--- a/mutest-driver/src/lib.rs
+++ b/mutest-driver/src/lib.rs
@@ -69,10 +69,7 @@ pub fn run(mut config: Config) -> CompilerResult<RunResult> {
         if config.opts.print_opts.print_headers { println!("\n@@@ code @@@\n"); }
         println!("{}", analysis_pass.generated_crate_code);
         if config.opts.print_opts.print_headers { println!(); }
-        if let config::Mode::Print = config.opts.mode && config.opts.print_opts.is_empty() {
-            if let Some(write_opts) = &config.opts.write_opts {
-                write_timings(write_opts, t_start.elapsed(), &analysis_pass, None, None);
-            }
+        if config.opts.outputs.last().copied() == Some(config::OutputKind::PrintInfo) && config.opts.print_opts.is_empty() {
             if config.opts.report_timings {
                 println!("finished in {total:.2?} (targets {targets:.2?}; mutations {mutations:.2?}; batching {batching:.2?}; codegen {codegen:.2?}; write {write:.2?})",
                     total = analysis_pass.duration,
@@ -98,21 +95,30 @@ pub fn run(mut config: Config) -> CompilerResult<RunResult> {
         specialized_external_mutant_crate = Some((crate_name, pass_result));
     }
 
-    let compilation_pass = passes::compilation::run(&config, &analysis_pass, specialized_external_mutant_crate.as_ref())?;
+    let compilation_pass = config.opts.outputs.contains(&config::OutputKind::TestBin).then(|| {
+        passes::compilation::run(&config, &analysis_pass, specialized_external_mutant_crate.as_ref())
+    }).transpose()?;
 
     if config.opts.report_timings {
-        if let Some(write_opts) = &config.opts.write_opts {
+        if config.opts.outputs.contains(&config::OutputKind::Metadata) {
             let specialized_external_mutant_pass = specialized_external_mutant_crate.as_ref().map(|(_, pass)| pass);
-            write_timings(write_opts, t_start.elapsed(), &analysis_pass, specialized_external_mutant_pass, Some(&compilation_pass));
+            write_timings(&config.opts.write_opts, t_start.elapsed(), &analysis_pass, specialized_external_mutant_pass, compilation_pass.as_ref());
         }
-        println!("finished in {total:.2?}",
-            total = t_start.elapsed(),
-        );
+
+        match &compilation_pass {
+            None => print!("finished in "),
+            Some(_) => {
+                println!("finished in {total:.2?}",
+                    total = t_start.elapsed(),
+                );
+                print!("analysis took ");
+            }
+        }
 
         match &specialized_external_mutant_crate {
             Some((_, specialized_external_mutant_pass)) => {
                 let Some(specialized_external_mutant_analysis_pass) = &specialized_external_mutant_pass.nested_run_result.analysis_pass else { unreachable!() };
-                println!("analysis took {analysis:.2?} (targets {targets:.2?}; mutations {mutations:.2?}; batching {batching:.2?}; hygiene {hygiene:.2?}; codegen {codegen:.2?}; write {write:.2?})",
+                println!("{analysis:.2?} (targets {targets:.2?}; mutations {mutations:.2?}; batching {batching:.2?}; hygiene {hygiene:.2?}; codegen {codegen:.2?}; write {write:.2?})",
                     analysis = analysis_pass.duration + specialized_external_mutant_analysis_pass.duration,
                     targets = analysis_pass.test_discovery_duration + analysis_pass.target_analysis_duration,
                     mutations = specialized_external_mutant_analysis_pass.mutation_generation_duration,
@@ -123,7 +129,7 @@ pub fn run(mut config: Config) -> CompilerResult<RunResult> {
                 );
             }
             None => {
-                println!("analysis took {analysis:.2?} (targets {targets:.2?}; mutations {mutations:.2?}; batching {batching:.2?}; hygiene {hygiene:.2?}; codegen {codegen:.2?}; write {write:.2?})",
+                println!("{analysis:.2?} (targets {targets:.2?}; mutations {mutations:.2?}; batching {batching:.2?}; hygiene {hygiene:.2?}; codegen {codegen:.2?}; write {write:.2?})",
                     analysis = analysis_pass.duration,
                     targets = analysis_pass.test_discovery_duration + analysis_pass.target_analysis_duration,
                     mutations = analysis_pass.mutation_generation_duration,
@@ -135,25 +141,27 @@ pub fn run(mut config: Config) -> CompilerResult<RunResult> {
             }
         };
 
-        match &specialized_external_mutant_crate {
-            Some((_, specialized_external_mutant_pass)) => {
-                let Some(specialized_external_mutant_compilation_pass) = &specialized_external_mutant_pass.nested_run_result.compilation_pass else { unreachable!() };
-                println!("compilations took {total:.2?} (mutant {mutant:.2?}, tests {tests:.2?})",
-                    total = specialized_external_mutant_compilation_pass.duration + compilation_pass.duration,
-                    mutant = specialized_external_mutant_compilation_pass.duration,
-                    tests = compilation_pass.duration,
-                );
-            }
-            None => {
-                println!("compilation took {compilation:.2?}",
-                    compilation = compilation_pass.duration,
-                );
+        if let Some(compilation_pass) = &compilation_pass {
+            match &specialized_external_mutant_crate {
+                Some((_, specialized_external_mutant_pass)) => {
+                    let Some(specialized_external_mutant_compilation_pass) = &specialized_external_mutant_pass.nested_run_result.compilation_pass else { unreachable!() };
+                    println!("compilations took {total:.2?} (mutant {mutant:.2?}, tests {tests:.2?})",
+                        total = specialized_external_mutant_compilation_pass.duration + compilation_pass.duration,
+                        mutant = specialized_external_mutant_compilation_pass.duration,
+                        tests = compilation_pass.duration,
+                    );
+                }
+                None => {
+                    println!("compilation took {compilation:.2?}",
+                        compilation = compilation_pass.duration,
+                    );
+                }
             }
         }
     }
 
     run_result.analysis_pass = Some(analysis_pass);
     run_result.specialized_external_mutant_pass = specialized_external_mutant_crate.map(|(_, pass)| pass);
-    run_result.compilation_pass = Some(compilation_pass);
+    run_result.compilation_pass = compilation_pass;
     Ok(run_result)
 }

--- a/mutest-driver/src/main.rs
+++ b/mutest-driver/src/main.rs
@@ -289,10 +289,10 @@ pub fn main() {
             let mut print_opts = config::PrintOptions {
                 print_headers: print_names.len() > 1,
                 tests: None,
-                mutation_targets: None,
                 call_graph: None,
-                conflict_graph: None,
+                mutation_targets: None,
                 mutations: None,
+                conflict_graph: None,
                 code: None,
             };
 
@@ -309,7 +309,6 @@ pub fn main() {
             for print_name in print_names {
                 match print_name {
                     opts::TESTS => print_opts.tests = Some(()),
-                    opts::TARGETS => print_opts.mutation_targets = Some(()),
                     opts::CALL_GRAPH => {
                         let entry_point_filters = mutest_arg_matches.get_many::<String>("call-graph-filter-entry-points").map(|s| s.map(|f| f.trim().to_owned()).collect::<Vec<_>>()).unwrap_or_default();
                         let non_local_call_view = {
@@ -322,12 +321,13 @@ pub fn main() {
                         };
                         print_opts.call_graph = Some(config::CallGraphOptions { format: graph_format, entry_point_filters, non_local_call_view });
                     }
+                    opts::TARGETS => print_opts.mutation_targets = Some(()),
+                    opts::MUTATIONS => print_opts.mutations = Some(()),
                     opts::CONFLICT_GRAPH | opts::COMPATIBILITY_GRAPH => {
                         let compatibility_graph = matches!(print_name, opts::COMPATIBILITY_GRAPH);
                         let exclude_unsafe = mutest_arg_matches.get_flag("graph-exclude-unsafe");
                         print_opts.conflict_graph = Some(config::ConflictGraphOptions { compatibility_graph, exclude_unsafe, format: graph_format });
                     }
-                    opts::MUTATIONS => print_opts.mutations = Some(()),
                     opts::CODE => print_opts.code = Some(()),
                     _ => unreachable!("invalid print information name: `{print_name}`"),
                 }

--- a/mutest-driver/src/main.rs
+++ b/mutest-driver/src/main.rs
@@ -359,7 +359,7 @@ pub fn main() {
         };
 
         let write_opts = {
-            let mut out_dir = mutest_arg_matches.get_one::<PathBuf>("json-out-root-dir").cloned()
+            let mut out_dir = mutest_arg_matches.get_one::<PathBuf>("metadata-out-root-dir").cloned()
                 .unwrap_or_else(|| mutest_target_dir_root.clone().unwrap_or(PathBuf::from("target/mutest")).join("json"));
 
             if let Some(cargo_package_name) = env::var("CARGO_PKG_NAME").ok() {

--- a/mutest-driver/src/main.rs
+++ b/mutest-driver/src/main.rs
@@ -9,6 +9,7 @@ extern crate rustc_interface;
 extern crate rustc_session;
 extern crate rustc_span;
 
+use std::collections::BTreeSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -164,6 +165,14 @@ mod crate_kind {
     }
 }
 
+mod emit {
+    mutest_driver_cli::opts! { ALL, pub(crate) possible_values where
+        INFO = "info"; ["Printed information requested via `--print`."]
+        METADATA = "metadata"; ["JSON mutation metadata."]
+        TEST_BIN = "test-bin"; ["Test binary."]
+    }
+}
+
 pub fn main() {
     let mut args = env::args().collect::<Vec<_>>();
 
@@ -217,6 +226,7 @@ pub fn main() {
         .no_binary_name(true)
         // Target-related Arguments
         .arg(clap::arg!(--"crate-kind" [CRATE_KIND] "Determine how the crate is handled in terms of mutations and tests.").value_parser(crate_kind::possible_values()).default_value(crate_kind::INFER).display_order(200))
+        .arg(clap::arg!(--emit [OUTPUT] "Outputs to emit for the crate, separated by commas. Compilation stops as soon as all emission goals have been met.").value_delimiter(',').value_parser(emit::possible_values()).default_value("all"))
         .get_matches_from(mutest_args.unwrap_or_default());
 
     process::exit(rustc_driver::catch_with_exit_code(|| {
@@ -271,10 +281,22 @@ pub fn main() {
             }
         };
 
-        let mode = match mutest_arg_matches.subcommand() {
-            Some(("print", _)) => config::Mode::Print,
-            Some(("build", _)) => config::Mode::Build,
-            _ => unreachable!(),
+        let outputs = {
+            use crate::emit as opts;
+
+            let mut emit_names = mutest_arg_matches.get_many::<String>("emit").map(|print| print.map(String::as_str).collect::<FxHashSet<_>>()).unwrap_or_default();
+            if emit_names.contains("all") { emit_names = FxHashSet::from_iter(opts::ALL.into_iter().map(|s| *s)); }
+
+            emit_names.into_iter()
+                .map(|emit_name| {
+                    match emit_name {
+                        opts::INFO => config::OutputKind::PrintInfo,
+                        opts::METADATA => config::OutputKind::Metadata,
+                        opts::TEST_BIN => config::OutputKind::TestBin,
+                        _ => unreachable!("invalid emit name: `{emit_name}`"),
+                    }
+                })
+                .collect::<BTreeSet<_>>()
         };
 
         let verbosity = mutest_arg_matches.get_count("verbose");
@@ -336,9 +358,7 @@ pub fn main() {
             print_opts
         };
 
-        let write_opts = 'write_opts: {
-            if mutest_arg_matches.get_flag("no-write-json") { break 'write_opts None; }
-
+        let write_opts = {
             let mut out_dir = mutest_arg_matches.get_one::<PathBuf>("json-out-root-dir").cloned()
                 .unwrap_or_else(|| mutest_target_dir_root.clone().unwrap_or(PathBuf::from("target/mutest")).join("json"));
 
@@ -373,7 +393,7 @@ pub fn main() {
                 fs::create_dir_all(&out_dir).expect(&format!("cannot create JSON output directory for crate at `{}`", out_dir.display()));
             }
 
-            Some(config::WriteOptions { out_dir })
+            config::WriteOptions { out_dir }
         };
 
         let unsafe_targeting = match () {
@@ -637,7 +657,7 @@ pub fn main() {
                 crate_kind,
                 cargo_target_kind,
 
-                mode,
+                outputs,
                 verbosity,
                 report_timings,
                 print_opts,

--- a/mutest-driver/src/passes/analysis.rs
+++ b/mutest-driver/src/passes/analysis.rs
@@ -23,7 +23,7 @@ use crate::passes::external_mutant::{ExternalTargets, StableTarget};
 use crate::passes::external_mutant::crate_const_storage;
 use crate::passes::external_mutant::specialized_crate::SpecializedMutantCrateCompilationRequest;
 use crate::print::{print_call_graph, print_mutations, print_mutation_graph, print_targets, print_tests};
-use crate::write::{write_call_graph, write_mutations, write_tests, write_timings};
+use crate::write::{write_call_graph, write_mutations, write_tests};
 
 pub struct AnalysisPassResult {
     pub duration: Duration,
@@ -197,20 +197,16 @@ pub fn run(config: &mut Config) -> CompilerResult<Option<AnalysisPassResult>> {
                 .unwrap_or_default();
             pass_result.test_discovery_duration = t_test_discovery_start.elapsed();
 
-            if let Some(write_opts) = &opts.write_opts && opts.crate_kind.provides_tests() {
+            if opts.outputs.contains(&config::OutputKind::Metadata) && opts.crate_kind.provides_tests() {
                 let t_write_start = Instant::now();
-                write_tests(write_opts, tcx, &tests, pass_result.test_discovery_duration);
+                write_tests(&opts.write_opts, tcx, &tests, pass_result.test_discovery_duration);
                 pass_result.write_duration += t_write_start.elapsed();
             }
 
             if let Some(_) = opts.print_opts.tests.take() && opts.crate_kind.provides_tests() {
                 if opts.print_opts.print_headers { println!("\n@@@ tests @@@\n"); }
                 print_tests(&tests);
-                if let config::Mode::Print = opts.mode && opts.print_opts.is_empty() {
-                    if let Some(write_opts) = &opts.write_opts {
-                        pass_result.duration = t_start.elapsed();
-                        write_timings(write_opts, t_start.elapsed(), &pass_result, None, None);
-                    }
+                if opts.outputs.last().copied() == Some(config::OutputKind::PrintInfo) && opts.print_opts.is_empty() {
                     if opts.report_timings {
                         println!("\nfinished in {total:.2?} (write {write:.2?})",
                             total = t_start.elapsed(),
@@ -294,9 +290,9 @@ pub fn run(config: &mut Config) -> CompilerResult<Option<AnalysisPassResult>> {
                     let (call_graph, mut reachable_fns) = mutest_emit::analysis::call_graph::reachable_fns(tcx, &def_res, &generated_crate_ast, entry_points, targeting, call_graph_depth_limit, call_graph_trace_length_limit);
                     let reachable_fns_count = reachable_fns.len();
                     let mut json_definitions = Default::default();
-                    if let Some(write_opts) = &opts.write_opts {
+                    if opts.outputs.contains(&config::OutputKind::Metadata) {
                         let t_write_start = Instant::now();
-                        json_definitions = write_call_graph(write_opts, tcx, all_mutable_fns_count, entry_points, &call_graph, &reachable_fns, t_target_analysis_start.elapsed());
+                        json_definitions = write_call_graph(&opts.write_opts, tcx, all_mutable_fns_count, entry_points, &call_graph, &reachable_fns, t_target_analysis_start.elapsed());
                         pass_result.write_duration += t_write_start.elapsed();
                     }
                     if opts.verbosity >= 1 {
@@ -333,12 +329,7 @@ pub fn run(config: &mut Config) -> CompilerResult<Option<AnalysisPassResult>> {
                     if let Some(config::CallGraphOptions { format, entry_point_filters, non_local_call_view }) = opts.print_opts.call_graph.take() {
                         if opts.print_opts.print_headers { println!("\n@@@ call graph @@@\n"); }
                         print_call_graph(tcx, entry_points, &call_graph, &reachable_fns, format, &entry_point_filters, non_local_call_view);
-                        if let config::Mode::Print = opts.mode && opts.print_opts.is_empty() {
-                            if let Some(write_opts) = &opts.write_opts {
-                                pass_result.duration = t_start.elapsed();
-                                pass_result.target_analysis_duration = t_target_analysis_start.elapsed();
-                                write_timings(write_opts, t_start.elapsed(), &pass_result, None, None);
-                            }
+                        if opts.outputs.last().copied() == Some(config::OutputKind::PrintInfo) && opts.print_opts.is_empty() {
                             if opts.report_timings {
                                 println!("\nfinished in {total:.2?} (targets {targets:.2?}; write {write:.2?})",
                                     total = t_start.elapsed(),
@@ -397,11 +388,7 @@ pub fn run(config: &mut Config) -> CompilerResult<Option<AnalysisPassResult>> {
                     if let Some(_) = opts.print_opts.mutation_targets.take() {
                         if opts.print_opts.print_headers { println!("\n@@@ targets @@@\n"); }
                         print_targets(tcx, &opts.crate_kind, &targets, opts.unsafe_targeting);
-                        if let config::Mode::Print = opts.mode && opts.print_opts.is_empty() {
-                            if let Some(write_opts) = &opts.write_opts {
-                                pass_result.duration = t_start.elapsed();
-                                write_timings(write_opts, t_start.elapsed(), &pass_result, None, None);
-                            }
+                        if opts.outputs.last().copied() == Some(config::OutputKind::PrintInfo) && opts.print_opts.is_empty() {
                             if opts.report_timings {
                                 println!("\nfinished in {total:.2?} (targets {targets:.2?}; write {write:.2?})",
                                     total = t_start.elapsed(),
@@ -561,11 +548,7 @@ pub fn run(config: &mut Config) -> CompilerResult<Option<AnalysisPassResult>> {
                     (true, false) => print_mutation_graph(&mutation_conflict_graph, mutations.iter(), mutation_conflict_graph.iter_compatibilities(), format),
                     (true, true) => print_mutation_graph(&mutation_conflict_graph, mutations_excluding_unsafe, mutation_conflict_graph.iter_compatibilities(), format),
                 }
-                if let config::Mode::Print = opts.mode && opts.print_opts.is_empty() {
-                    if let Some(write_opts) = &opts.write_opts {
-                        pass_result.duration = t_start.elapsed();
-                        write_timings(write_opts, t_start.elapsed(), &pass_result, None, None);
-                    }
+                if opts.outputs.last().copied() == Some(config::OutputKind::PrintInfo) && opts.print_opts.is_empty() {
                     if opts.report_timings {
                         println!("\nfinished in {total:.2?} (targets {targets:.2?}; mutations {mutations:.2?}; conflicts {conflicts:.2?}; write {write:.2?})",
                             total = t_start.elapsed(),
@@ -650,20 +633,16 @@ pub fn run(config: &mut Config) -> CompilerResult<Option<AnalysisPassResult>> {
                 }
             };
 
-            if let Some(write_opts) = &opts.write_opts {
+            if opts.outputs.contains(&config::OutputKind::Metadata) {
                 let t_write_start = Instant::now();
-                write_mutations(write_opts, tcx, all_mutable_fns_count, &json_definitions, &targets, &mutations, opts.unsafe_targeting, &mutation_conflict_graph, mutation_parallelism, t_mutation_generation_start.elapsed());
+                write_mutations(&opts.write_opts, tcx, all_mutable_fns_count, &json_definitions, &targets, &mutations, opts.unsafe_targeting, &mutation_conflict_graph, mutation_parallelism, t_mutation_generation_start.elapsed());
                 pass_result.write_duration += t_write_start.elapsed();
             }
 
             if let Some(_) = opts.print_opts.mutations.take() {
                 if opts.print_opts.print_headers { println!("\n@@@ mutations @@@\n"); }
                 print_mutations(tcx, &mutations, mutation_batches.as_deref(), opts.unsafe_targeting, opts.verbosity);
-                if let config::Mode::Print = opts.mode && opts.print_opts.is_empty() {
-                    if let Some(write_opts) = &opts.write_opts {
-                        pass_result.duration = t_start.elapsed();
-                        write_timings(write_opts, t_start.elapsed(), &pass_result, None, None);
-                    }
+                if opts.outputs.last().copied() == Some(config::OutputKind::PrintInfo) && opts.print_opts.is_empty() {
                     if opts.report_timings {
                         println!("\nfinished in {total:.2?} (targets {targets:.2?}; mutations {mutations:.2?}; batching {batching:.2?}; write {write:.2?})",
                             total = t_start.elapsed(),

--- a/mutest-driver/src/passes/external_mutant/specialized_crate.rs
+++ b/mutest-driver/src/passes/external_mutant/specialized_crate.rs
@@ -26,7 +26,7 @@ pub struct NestedRunResult {
 pub struct SpecializedMutantCrateCompilationResult {
     pub nested_run_result: NestedRunResult,
     pub duration: Duration,
-    pub outputs: Arc<OutputFilenames>,
+    pub outputs: Option<Arc<OutputFilenames>>,
 }
 
 pub fn compile_specialized_mutant_crate(
@@ -73,7 +73,7 @@ pub fn compile_specialized_mutant_crate(
             //       as the two crates represent a single pass.
             cargo_target_kind: config.opts.cargo_target_kind,
 
-            mode: config::Mode::Build,
+            outputs: config.opts.outputs.clone(),
             verbosity: config.opts.verbosity,
             // NOTE: We report timings for this compilation pass separately.
             report_timings: false,
@@ -110,8 +110,7 @@ pub fn compile_specialized_mutant_crate(
     }
 
     let run_result = run_result?;
-    let Some(compilation_pass) = &run_result.compilation_pass else { unreachable!("no compiled output from specialized mutant crate") };
-    let outputs = compilation_pass.outputs.clone();
+    let outputs = run_result.compilation_pass.as_ref().map(|compilation_pass| compilation_pass.outputs.clone());
 
     Ok(SpecializedMutantCrateCompilationResult {
         nested_run_result: NestedRunResult {

--- a/mutest-inspector/src/config.rs
+++ b/mutest-inspector/src/config.rs
@@ -13,6 +13,6 @@ pub struct Options {
 }
 
 pub struct Config {
-    pub json_root_dir_path: PathBuf,
+    pub metadata_root_dir_path: PathBuf,
     pub opts: Options,
 }

--- a/mutest-inspector/src/lib.rs
+++ b/mutest-inspector/src/lib.rs
@@ -33,17 +33,17 @@ use crate::syntax_highlight::SyntaxHighlighter;
 struct TargetMetadataDir {
     package: String,
     target: TargetSpec,
-    json_dir_path: PathBuf,
+    metadata_dir_path: PathBuf,
 }
 
-fn register_target_metadata_dir_if_exists(targets: &mut Vec<TargetMetadataDir>, package: &str, target: TargetSpec, json_dir_path: PathBuf) {
-    let mutations_json_file_path = json_dir_path.join("mutations.json");
+fn register_target_metadata_dir_if_exists(targets: &mut Vec<TargetMetadataDir>, package: &str, target: TargetSpec, metadata_dir_path: PathBuf) {
+    let mutations_json_file_path = metadata_dir_path.join("mutations.json");
     if !fs::exists(&mutations_json_file_path).expect(&format!("cannot read mutations metadata file `{}`", mutations_json_file_path.display())) { return; }
 
     targets.push(TargetMetadataDir {
         package: package.to_owned(),
         target,
-        json_dir_path,
+        metadata_dir_path,
     });
 }
 
@@ -65,11 +65,11 @@ fn register_nested_target_metadata_dirs(targets: &mut Vec<TargetMetadataDir>, pa
     }
 }
 
-fn discover_target_metadata_dirs_in_json_root_dir(json_root_dir_path: &Path) -> Vec<TargetMetadataDir> {
+fn discover_target_metadata_dirs_in_json_root_dir(metadata_root_dir_path: &Path) -> Vec<TargetMetadataDir> {
     let mut target_metadata_dirs = Vec::new();
 
-    for entry in fs::read_dir(json_root_dir_path).expect(&format!("cannot read json root directory `{}`", json_root_dir_path.display())) {
-        let entry = entry.expect(&format!("cannot read entry in json root directory `{}`", json_root_dir_path.display()));
+    for entry in fs::read_dir(metadata_root_dir_path).expect(&format!("cannot read metadata root directory `{}`", metadata_root_dir_path.display())) {
+        let entry = entry.expect(&format!("cannot read entry in json root directory `{}`", metadata_root_dir_path.display()));
         let json_package_dir_path = entry.path();
         if !json_package_dir_path.is_dir() { continue; }
 
@@ -97,15 +97,15 @@ struct TargetMetadata {
 }
 
 fn load_target_metadata(target_metadata_dir: TargetMetadataDir) -> TargetMetadata {
-    let call_graph_metadata_file_path = target_metadata_dir.json_dir_path.join("call_graph.json");
+    let call_graph_metadata_file_path = target_metadata_dir.metadata_dir_path.join("call_graph.json");
     let call_graph_metadata_file_str = fs::read_to_string(&call_graph_metadata_file_path).expect(&format!("cannot read call graph metadata file `{}`", call_graph_metadata_file_path.display()));
     let call_graph_metadata = serde_json::from_str::<mutest_json::call_graph::CallGraphInfo>(&call_graph_metadata_file_str).expect("cannot parse call graph metadata file");
 
-    let mutations_metadata_file_path = target_metadata_dir.json_dir_path.join("mutations.json");
+    let mutations_metadata_file_path = target_metadata_dir.metadata_dir_path.join("mutations.json");
     let mutations_metadata_file_str = fs::read_to_string(&mutations_metadata_file_path).expect(&format!("cannot read mutations metadata file `{}`", mutations_metadata_file_path.display()));
     let mutations_metadata = serde_json::from_str::<mutest_json::mutations::MutationsInfo>(&mutations_metadata_file_str).expect("cannot parse mutations metadata file");
 
-    let evaluation_metadata_file_path = target_metadata_dir.json_dir_path.join("evaluation.json");
+    let evaluation_metadata_file_path = target_metadata_dir.metadata_dir_path.join("evaluation.json");
     let evaluation_metadata_file_str = match fs::read_to_string(&evaluation_metadata_file_path) {
         Ok(v) => Some(v),
         Err(err) if let io::ErrorKind::NotFound = err.kind() => None,
@@ -134,10 +134,10 @@ fn load_target_metadata(target_metadata_dir: TargetMetadataDir) -> TargetMetadat
 pub async fn run(config: Config) {
     let t_start = Instant::now();
 
-    let target_metadata_dirs = discover_target_metadata_dirs_in_json_root_dir(&config.json_root_dir_path);
+    let target_metadata_dirs = discover_target_metadata_dirs_in_json_root_dir(&config.metadata_root_dir_path);
 
     if target_metadata_dirs.is_empty() {
-        println!("could not discover any targets in `{}`", config.json_root_dir_path.display());
+        println!("could not discover any targets in `{}`", config.metadata_root_dir_path.display());
         process::exit(1);
     }
 

--- a/mutest-inspector/src/main.rs
+++ b/mutest-inspector/src/main.rs
@@ -17,14 +17,14 @@ async fn main() {
                 .literal(Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightBlue))).bold())
                 .placeholder(Style::new().fg_color(Some(Color::Ansi(AnsiColor::BrightBlue))))
         })
-        .arg(clap::arg!(--"json-root-dir" [JSON_ROOT_DIR] "Path to JSON metadata files from a mutest-rs analysis.").value_parser(clap::value_parser!(PathBuf)).default_value("target/mutest/json"))
+        .arg(clap::arg!(--"metadata-root-dir" [JSON_ROOT_DIR] "Path to JSON metadata files from a mutest-rs analysis.").value_parser(clap::value_parser!(PathBuf)).default_value("target/mutest/json"))
         .arg(clap::arg!(--port [PORT] "Port number to serve interface on.").value_parser(clap::value_parser!(u16)).default_value("3000"))
         .arg(clap::arg!(--open [TARGET_SPEC] "Open the interface in a browser. Optionally, a specific package to open may be specified by name, or a target by target spec syntax (e.g., `package/lib`, or `package/test:integration_test`).").num_args(0..=1).require_equals(true))
         .arg(clap::arg!(-h --help "Print help information; this message or the help of the given subcommand.").action(clap::ArgAction::Help).global(true))
         .arg(clap::arg!(-V --version "Print version information.").action(clap::ArgAction::Version).global(true))
         .get_matches();
 
-    let Some(json_root_dir_path) = matches.get_one::<PathBuf>("json-root-dir").cloned() else { unreachable!() };
+    let Some(metadata_root_dir_path) = matches.get_one::<PathBuf>("metadata-root-dir").cloned() else { unreachable!() };
 
     let port = *matches.get_one::<u16>("port").unwrap();
 
@@ -54,7 +54,7 @@ async fn main() {
     };
 
     let config = Config {
-        json_root_dir_path,
+        metadata_root_dir_path,
         opts: config::Options {
             port,
             open,

--- a/mutest-runtime-embedded-host-driver/src/main.rs
+++ b/mutest-runtime-embedded-host-driver/src/main.rs
@@ -43,9 +43,9 @@ fn main() {
         .arg(clap::arg!(-v --verbose "Print more verbose information during execution.").action(clap::ArgAction::Count).default_value("0").display_order(100))
         .arg(clap::arg!(--print [PRINT] "Print additional information during mutation evaluation. Multiple may be specified, separated by commas.").value_delimiter(',').action(clap::ArgAction::Append).value_parser(print::possible_values()).display_order(101))
         // Metadata-related Arguments
-        .arg(clap::arg!(--"json-out-root-dir" [OUT_DIR] "Write JSON metadata files into the specified output directory.").value_parser(clap::value_parser!(PathBuf)).display_order(105))
+        .arg(clap::arg!(--"metadata-out-root-dir" [OUT_DIR] "Write JSON metadata files into the specified output directory.").value_parser(clap::value_parser!(PathBuf)).display_order(105))
         // Experimental Flags
-        .arg(clap::arg!(--"Zwrite-json-eval-stream" "Write JSONL stream file into JSON output directory specified by `--json-out-root-dir`.").display_order(500))
+        .arg(clap::arg!(--"Zwrite-json-eval-stream" "Write JSONL stream file into JSON output directory specified by `--metadata-out-root-dir`.").display_order(500))
         // Information
         // FIXME: Regression; the `help` subcommand can no longer be customized,
         //        so the about text does not match that of the help flags.
@@ -92,7 +92,7 @@ fn main() {
     };
 
     let write_opts = 'write_opts: {
-        let Some(out_dir) = matches.get_one::<PathBuf>("json-out-root-dir").cloned() else {
+        let Some(out_dir) = matches.get_one::<PathBuf>("metadata-out-root-dir").cloned() else {
             break 'write_opts None;
         };
         // TODO: Determine specific package target out dir path from the test bin being tested.

--- a/mutest-runtime/src/harness.rs
+++ b/mutest-runtime/src/harness.rs
@@ -870,7 +870,7 @@ pub fn mutest_main(args: &[&str], tests: Vec<test::TestDescAndFn>, external_test
             detection_matrix: args.contains(&"--print=detection-matrix").then_some(()),
             subsumption_matrix: args.contains(&"--print=subsumption-matrix").then_some(()),
         },
-        write_opts: args.iter().flat_map(|arg| arg.strip_prefix("--json-out-root-dir=")).next().map(|out_dir_str| {
+        write_opts: args.iter().flat_map(|arg| arg.strip_prefix("--metadata-out-root-dir=")).next().map(|out_dir_str| {
             let mut out_dir = PathBuf::from(out_dir_str);
 
             if let Some(cargo_package_name) = meta_mutant.cargo_package_name {

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -279,56 +279,51 @@ fn run_test(path: &Path, aux_dir_path: &Path, root_dir: &Path, opts: &Opts, resu
     let mut mutest_prints = BTreeSet::new();
     let mut exec_build_artifact = false;
     let mut expect_run_fail = false;
-    let mut mutest_subcommand: Option<&str> = None;
+    let mut mutest_outputs: Vec<&str> = vec!["info"];
     for directive in &directives {
         match directive.as_str() {
             action_directive @ ("print-tests" | "print-call-graph" | "print-targets" | "print-mutations" | "print-code" | "build" | "build: fail" | "run" | "run: fail") => {
-                // NOTE: The invariant here is that the moment any action directive resulting in the `build` subcommand is used,
+                // NOTE: The invariant here is that the moment any action directive resulting in the `test-bin` output is used,
                 //       then no other action directive of any kind can be specified afterwards.
                 //       This ensures the following:
                 //         1. `print-*` action directives must appear before any other action directive, e.g. `build`, and
                 //         2. the `build`, `build: fail`, `run`, `run: fail` action directives are mutually exclusive.
-                if let Some(previous_subcommand) = mutest_subcommand && previous_subcommand != "print" {
+                if mutest_outputs.contains(&"test-bin") {
                     results.ignored_tests_count += 1;
                     log_test(&name, TestResult::Ignored, Some("invalid action directives"));
                     return;
                 }
                 match action_directive {
                     "build" => {
-                        mutest_subcommand = Some("build");
+                        mutest_outputs.push("test-bin");
                     }
                     "build: fail" => {
                         expect_build_fail = true;
-                        mutest_subcommand = Some("build");
+                        mutest_outputs.push("test-bin");
                     }
                     "run" => {
                         exec_build_artifact = true;
-                        mutest_subcommand = Some("build")
+                        mutest_outputs.push("test-bin");
                     }
                     "run: fail" => {
                         exec_build_artifact = true;
                         expect_run_fail = true;
-                        mutest_subcommand = Some("build")
+                        mutest_outputs.push("test-bin");
                     }
                     "print-tests" => {
                         mutest_prints.insert("tests");
-                        mutest_subcommand.get_or_insert("print");
                     }
                     "print-call-graph" => {
                         mutest_prints.insert("call-graph");
-                        mutest_subcommand.get_or_insert("print");
                     }
                     "print-targets" => {
                         mutest_prints.insert("targets");
-                        mutest_subcommand.get_or_insert("print");
                     }
                     "print-mutations" => {
                         mutest_prints.insert("mutations");
-                        mutest_subcommand.get_or_insert("print");
                     }
                     "print-code" => {
                         mutest_prints.insert("code");
-                        mutest_subcommand.get_or_insert("print");
                     }
                     _ => unreachable!(),
                 };
@@ -380,7 +375,6 @@ fn run_test(path: &Path, aux_dir_path: &Path, root_dir: &Path, opts: &Opts, resu
 
     // Set defaults.
     let edition = edition.unwrap_or("2018");
-    let mutest_subcommand = mutest_subcommand.unwrap_or("build");
 
     // HACK: We invoke mutest-driver directly, rather than through Cargo, which means
     //       we have to add `windows.lib` to the linker search path manually.
@@ -541,7 +535,7 @@ fn run_test(path: &Path, aux_dir_path: &Path, root_dir: &Path, opts: &Opts, resu
         cmd.args(["-L", AUX_OUT_DIR]);
     }
 
-    let mut mutest_args = vec!["--no-write-json".to_owned()];
+    let mut mutest_args = vec![format!("--emit={}", mutest_outputs.join(","))];
     let mut verifications = directives.iter().filter_map(|d| d.strip_prefix("verify:").map(str::trim))
         .flat_map(|flags| flags.split(",").map(str::trim).filter(|flag| !flag.is_empty()))
         .peekable();
@@ -563,7 +557,6 @@ fn run_test(path: &Path, aux_dir_path: &Path, root_dir: &Path, opts: &Opts, resu
     directives.iter().filter_map(|d| d.strip_prefix("mutest-flags:").map(str::trim))
         .flat_map(|flags| parse_args(flags).into_iter().map(str::to_owned))
         .collect_into(&mut mutest_args);
-    mutest_args.push(mutest_subcommand.to_owned());
     cmd.env("MUTEST_ENCODED_ARGS".to_owned(), mutest_args.join("\x1F"));
 
     // NOTE: Avoid passing on the `CARGO_*` environment variables from the test runner.


### PR DESCRIPTION
This PR restructures the mutest-driver and cargo-mutest CLIs with the following goals in mind:

* Remove subcommands (`build`, `print`) from mutest-driver to create a simpler interface more similar to rustc-driver. Replace the subcommands with a more flexible `--emit=[info|metadata|test-bin...]` option, which controls both which outputs are generated, and when the compilation can be stopped, i.e., once all emission goals are met. This change also removes the `--no-write-json` flag from mutest-driver, which is now represented by a lack of `--emit=metadata`.
* Consolidate the cargo-mutest subcommands for invoking mutest-driver (`run`, `build`, `print`)  under a single `run` subcommand. Replace the `print` subcommand with the `--no-build` flag (corresponds to `--emit=info` in mutest-driver), and the `build` subcommand with the `--no-eval` flag (corresponds to `--emit=info,test-bin` in mutest-driver). This simplifies argument ordering: because there are now no global arguments, all arguments follow the subcommand, e.g., `cargo mutest run -p package --print=mutations --isolate=all`.
* Rename `--no-write-json` to `--no-emit-metadata` in cargo-mutest, which now controls JSON metadata emission through the exclusion of the `--emit=metadata` option. Other `json` options have also been renamed to use `metadata` instead, such as `--json-out-root-dir` becoming `--metadata-out-root-dir`.
* Add the `inspect` subcommand to cargo-mutest for invoking mutest-inspector on a Cargo workspace.

These changes prepare cargo-mutest to be more than just a Cargo-compatible wrapper around mutest-driver, and for cargo-mutest to have more subcommands in the future.